### PR TITLE
Avoid 'getBoundingClientRect-is-undefined'

### DIFF
--- a/src/foundation/cameras/WalkThroughCameraController.ts
+++ b/src/foundation/cameras/WalkThroughCameraController.ts
@@ -188,7 +188,12 @@ export default class WalkThroughCameraController implements ICameraController {
     this._isMouseDown = false;
     this._isMouseDrag = false;
 
-    let rect = (evt.target! as any).getBoundingClientRect();
+    const target = evt.target as any;
+    if (target?.getBoundingClientRect == null) {
+      return;
+    }
+
+    const rect = target.getBoundingClientRect();
     this._clickedMouseXOnCanvas = evt.clientX - rect.left;
     this._clickedMouseYOnCanvas = evt.clientY - rect.top;
   }


### PR DESCRIPTION
When we use WalkThroughCameraController, the error that is in the following image is happen. I fixed it.

![image](https://user-images.githubusercontent.com/7972283/85530174-b17ed000-b648-11ea-8e3d-2edfb29bee77.png)
