### PR TITLE
Fix invalid memory allocation for the PhysicsComponent

### DIFF
--- a/src/foundation/components/PhysicsComponent.ts
+++ b/src/foundation/components/PhysicsComponent.ts
@@ -13,7 +13,6 @@ export default class PhysicsComponent extends Component {
   constructor(entityUid: EntityUID, componentSid: ComponentSID, entityComponent: EntityRepository) {
     super(entityUid, componentSid, entityComponent);
 
-    this.submitToAllocation(this.maxNumberOfComponent);
     this.moveStageTo(ProcessStage.Logic);
   }
 


### PR DESCRIPTION
When users use the PhysicsComponent, they get the following error:
![image](https://user-images.githubusercontent.com/7972283/89976206-c10eb280-dca2-11ea-82c7-27caddb570b7.png)

The submitToAllocation method allocates memory to the member variables registered in the registerMember method. However, there are no registerMember method in the PhysicsComponent. I solved the problem by removing the submitToAllocation method.

