### PR TITLE
Fix ray cast for object that have indices

### DIFF
--- a/src/foundation/geometry/Primitive.ts
+++ b/src/foundation/geometry/Primitive.ts
@@ -381,11 +381,16 @@ export default class Primitive extends RnObject {
       return { currentShortestIntersectedPosVec3, currentShortestT };
     }
 
-    if (!this.hasIndices()) {
-      for (let i = 0; i < positionAccessor.elementCount; i += incrementNum) {
-        const pos0IndexBase = i;
-        const pos1IndexBase = i + 1;
-        const pos2IndexBase = i + 2;
+    if (this.hasIndices()) {
+      for (let i = 0; i < this.__indices!.elementCount - 2; i++) {
+        const j = i * incrementNum;
+        if (j + 2 > this.__indices!.elementCount - 1) {
+          // gl.TRIANGLES
+          break;
+        }
+        let pos0IndexBase = this.__indices!.getScalar(j, {});
+        let pos1IndexBase = this.__indices!.getScalar(j + 1, {});
+        let pos2IndexBase = this.__indices!.getScalar(j + 2, {});
 
         const result = this.__castRayInner(
           origVec3,
@@ -408,15 +413,10 @@ export default class Primitive extends RnObject {
         }
       }
     } else {
-      for (let i = 0; i < this.__indices!.elementCount - 2; i++) {
-        const j = i * incrementNum;
-        if (j + 2 > this.__indices!.elementCount - 1) {
-          // gl.TRIANGLES
-          break;
-        }
-        let pos0IndexBase = this.__indices!.getScalar(j, {});
-        let pos1IndexBase = this.__indices!.getScalar(j + 1, {});
-        let pos2IndexBase = this.__indices!.getScalar(j + 2, {});
+      for (let i = 0; i < positionAccessor.elementCount; i += incrementNum) {
+        const pos0IndexBase = i;
+        const pos1IndexBase = i + 1;
+        const pos2IndexBase = i + 2;
 
         const result = this.__castRayInner(
           origVec3,
@@ -518,15 +518,7 @@ export default class Primitive extends RnObject {
 
     this.__inverseArenbergMatrix = [];
     this.__arenberg3rdPosition = [];
-    if (!this.hasIndices()) {
-      for (let i = 0; i < positionAccessor.elementCount - 2; i += incrementNum) {
-        const pos0IndexBase = i;
-        const pos1IndexBase = i + 1;
-        const pos2IndexBase = i + 2;
-
-        this._calcArenbergMatrixFor3Vertices(i, pos0IndexBase, pos1IndexBase, pos2IndexBase);
-      }
-    } else {
+    if (this.hasIndices()) {
       for (let i = 0; i < this.__indices!.elementCount - 2; i++) {
         const j = i * incrementNum;
         if (j + 2 > this.__indices!.elementCount - 1) {
@@ -536,6 +528,14 @@ export default class Primitive extends RnObject {
         let pos0IndexBase = this.__indices!.getScalar(j, {});
         let pos1IndexBase = this.__indices!.getScalar(j + 1, {});
         let pos2IndexBase = this.__indices!.getScalar(j + 2, {});
+
+        this._calcArenbergMatrixFor3Vertices(i, pos0IndexBase, pos1IndexBase, pos2IndexBase);
+      }
+    } else {
+      for (let i = 0; i < positionAccessor.elementCount - 2; i += incrementNum) {
+        const pos0IndexBase = i;
+        const pos1IndexBase = i + 1;
+        const pos2IndexBase = i + 2;
 
         this._calcArenbergMatrixFor3Vertices(i, pos0IndexBase, pos1IndexBase, pos2IndexBase);
       }


### PR DESCRIPTION
This PR fixes #609.

I fixed the end condition of the for statement in 5a62d66.

The for statement was supposed to repeat the number of triangles, but it repeats about three times as many the number of triangles when the mode of primitive is gl.TRIANGLES,
