### PR TITLE
Unify the calculation method of zNear and zFar

### DIFF
--- a/src/foundation/cameras/AbstractCameraController.ts
+++ b/src/foundation/cameras/AbstractCameraController.ts
@@ -1,0 +1,53 @@
+import CameraComponent from "../components/CameraComponent";
+import AABB from "../math/AABB";
+import Vector3 from "../math/Vector3";
+
+export default abstract class AbstractCameraController {
+  public zNearLimitFactor = 10; // must be more than 0
+  public zFarScalingFactor = 10000;
+  public autoCalculateZNearAndZFar = true;
+
+  constructor() {
+  }
+
+  protected _calcZNearInner(camera: CameraComponent, eyePosition: Vector3, eyeDirection: Vector3, targetAABB: AABB) {
+    if (this.autoCalculateZNearAndZFar) {
+      const lengthOfCenterToEye = Vector3.lengthBtw(eyePosition, targetAABB.centerPoint);
+      const sizeMin = Math.min(targetAABB.sizeX, targetAABB.sizeY, targetAABB.sizeZ);
+
+      // avoid minLimit equals to 0
+      const halfSizeMinNon0 = sizeMin > 0 ? sizeMin / 2 :
+        Math.min(
+          targetAABB.sizeX > 0 ? targetAABB.sizeX : Infinity,
+          targetAABB.sizeY > 0 ? targetAABB.sizeY : Infinity,
+          targetAABB.sizeZ > 0 ? targetAABB.sizeZ : Infinity
+        ) / 2;
+
+      const minLimit = halfSizeMinNon0 / this.zNearLimitFactor;
+
+      if (lengthOfCenterToEye - targetAABB.lengthCenterToCorner < minLimit) {
+        camera.zNearInner = minLimit
+        return;
+      }
+
+      // calc cos between eyeToTarget and eye direction
+      const eyeToTargetDirectionX = targetAABB.centerPoint.v[0] - eyePosition.v[0];
+      const eyeToTargetDirectionY = targetAABB.centerPoint.v[1] - eyePosition.v[1];
+      const eyeToTargetDirectionZ = targetAABB.centerPoint.v[2] - eyePosition.v[2];
+      const cos = (eyeToTargetDirectionX * eyeDirection.v[0] + eyeToTargetDirectionY * eyeDirection.v[1] + eyeToTargetDirectionZ * eyeDirection.v[2])
+        / (Math.hypot(eyeToTargetDirectionX, eyeToTargetDirectionY, eyeToTargetDirectionZ) * eyeDirection.length());
+
+      camera.zNearInner = Math.max(lengthOfCenterToEye * cos - targetAABB.lengthCenterToCorner, minLimit);
+    } else {
+      camera.zNearInner = camera.zNear;
+    }
+  }
+
+  protected _calcZFarInner(camera: CameraComponent) {
+    if (this.autoCalculateZNearAndZFar) {
+      camera.zFarInner = camera.zNearInner * this.zFarScalingFactor;
+    } else {
+      camera.zNearInner = camera.zFar;
+    }
+  }
+}

--- a/src/foundation/cameras/AbstractCameraController.ts
+++ b/src/foundation/cameras/AbstractCameraController.ts
@@ -1,17 +1,19 @@
 import CameraComponent from "../components/CameraComponent";
-import AABB from "../math/AABB";
+import Entity from "../core/Entity";
 import Vector3 from "../math/Vector3";
 
 export default abstract class AbstractCameraController {
   public zNearLimitFactor = 10; // must be more than 0
   public zFarScalingFactor = 10000;
   public autoCalculateZNearAndZFar = true;
+  protected abstract __targetEntity?: Entity;
 
   constructor() {
   }
 
-  protected _calcZNearInner(camera: CameraComponent, eyePosition: Vector3, eyeDirection: Vector3, targetAABB: AABB) {
-    if (this.autoCalculateZNearAndZFar) {
+  protected _calcZNearInner(camera: CameraComponent, eyePosition: Vector3, eyeDirection: Vector3) {
+    if (this.autoCalculateZNearAndZFar && this.__targetEntity != null) {
+      const targetAABB = this.__targetEntity.getSceneGraph().worldAABB;
       const lengthOfCenterToEye = Vector3.lengthBtw(eyePosition, targetAABB.centerPoint);
       const sizeMin = Math.min(targetAABB.sizeX, targetAABB.sizeY, targetAABB.sizeZ);
 
@@ -50,4 +52,7 @@ export default abstract class AbstractCameraController {
       camera.zNearInner = camera.zFar;
     }
   }
+
+  abstract setTarget(targetEntity: Entity): void;
+  abstract getTarget(): Entity | undefined;
 }

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -42,7 +42,6 @@ export default class OrbitCameraController implements ICameraController {
   private __eyeVec = MutableVector3.zero();
   private __centerVec = MutableVector3.zero();
   private __upVec = MutableVector3.zero();
-  private __shiftCameraTo = MutableVector3.zero();
   private __targetEntity?: Entity;
   public scaleOfLengthCenterToCamera = 1.0;
   private __zFarAdjustingFactorBasedOnAABB = 150;
@@ -677,9 +676,6 @@ export default class OrbitCameraController implements ICameraController {
         invMat.multiplyVector3To(newUpVec, newUpVec);
       }
     }
-
-    newEyeVec.add(this.__shiftCameraTo);
-    newCenterVec.add(this.__shiftCameraTo);
   }
 
   set scaleOfZNearAndZFar(value: number) {

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -505,10 +505,14 @@ export default class OrbitCameraController implements ICameraController {
 
   logic(cameraComponent: CameraComponent) {
     this.__updateTargeting(cameraComponent);
+    this.__calculateInfluenceOfController();
     this.__updateCameraComponent(cameraComponent);
   }
 
-  __updateCameraComponent(camera: CameraComponent) {
+  /**
+   * @private calculate up, eye, center and tangent vector with controller influence
+   */
+  __calculateInfluenceOfController() {
     const centerToEyeVec = this.__eyeVec.subtract(this.__centerVec);
     centerToEyeVec.multiply(this.__dolly * this.dollyScale);
 
@@ -582,7 +586,9 @@ export default class OrbitCameraController implements ICameraController {
       newEyeVec.add(this.__mouseTranslateVec);
       newCenterVec.add(this.__mouseTranslateVec);
     }
+  }
 
+  __updateCameraComponent(camera: CameraComponent) {
     let newLeft = camera.left;
     let newRight = camera.right;
     let newTop = camera.top;
@@ -594,7 +600,7 @@ export default class OrbitCameraController implements ICameraController {
     const targetAABB = this.__getTargetAABB();
 
     if (this.__targetEntity) {
-      newZFar = newZNear + Vector3.lengthBtw(newCenterVec, newEyeVec);
+      newZFar = newZNear + Vector3.lengthBtw(this.__newCenterVec, this.__newEyeVec);
       newZFar += targetAABB.lengthCenterToCorner * this.__zFarAdjustingFactorBasedOnAABB;
     }
 
@@ -619,9 +625,9 @@ export default class OrbitCameraController implements ICameraController {
     const fovy = this.__getFovyFromCamera(camera);
     this.__fovyBias = Math.tan(MathUtil.degreeToRadian(fovy / 2.0));
 
-    camera.eyeInner = newEyeVec;
-    camera.directionInner = newCenterVec;
-    camera.upInner = newUpVec;
+    camera.eyeInner = this.__newEyeVec;
+    camera.directionInner = this.__newCenterVec;
+    camera.upInner = this.__newUpVec;
     camera.zNearInner = newZNear;
     camera.zFarInner = newZFar;
     camera.leftInner = newLeft;

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -83,6 +83,7 @@ export default class OrbitCameraController extends AbstractCameraController impl
   private static readonly __tmp_up: Vector3 = new Vector3(0, 0, 1);
   private static __tmpVec3_0: MutableVector3 = MutableVector3.zero();
   private static __tmpVec3_1: MutableVector3 = MutableVector3.zero();
+  private static __tmpVec3_2: MutableVector3 = MutableVector3.zero();
 
   private static __tmp_rotateM_X: MutableMatrix33 = MutableMatrix33.identity();
   private static __tmp_rotateM_Y: MutableMatrix33 = MutableMatrix33.identity();
@@ -515,7 +516,7 @@ export default class OrbitCameraController extends AbstractCameraController impl
    * @private calculate up, eye, center and tangent vector with controller influence
    */
   __calculateInfluenceOfController() {
-    const centerToEyeVec = this.__eyeVec.subtract(this.__centerVec);
+    const centerToEyeVec = MutableVector3.subtractTo(this.__eyeVec, this.__centerVec, OrbitCameraController.__tmpVec3_0);
     centerToEyeVec.multiply(this.__dolly * this.dollyScale);
 
     this.__lengthOfCenterToEye = centerToEyeVec.length();
@@ -526,7 +527,7 @@ export default class OrbitCameraController extends AbstractCameraController impl
     const newTangentVec = this.__newTangentVec;
 
     if (this.__isSymmetryMode) {
-      const projectedCenterToEyeVec = OrbitCameraController.__tmpVec3_0;
+      const projectedCenterToEyeVec = OrbitCameraController.__tmpVec3_1;
       projectedCenterToEyeVec.setComponents(centerToEyeVec.x, 0, centerToEyeVec.z);
 
       let horizontalAngleOfVectors = Vector3.angleOfVectors(projectedCenterToEyeVec, OrbitCameraController.__tmp_up);
@@ -553,7 +554,7 @@ export default class OrbitCameraController extends AbstractCameraController impl
       rotateM.multiplyVectorTo(centerToEyeVec, newEyeVec).add(this.__centerVec);
       newCenterVec.copyComponents(this.__centerVec);
 
-      const newEyeToCenterVec = OrbitCameraController.__tmpVec3_1;
+      const newEyeToCenterVec = OrbitCameraController.__tmpVec3_2;
       MutableVector3.subtractTo(newCenterVec, newEyeVec, newEyeToCenterVec);
       MutableVector3.crossTo(newUpVec, newEyeToCenterVec, newTangentVec);
 

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -43,7 +43,7 @@ export default class OrbitCameraController extends AbstractCameraController impl
   private __eyeVec = MutableVector3.zero();
   private __centerVec = MutableVector3.zero();
   private __upVec = MutableVector3.zero();
-  private __targetEntity?: Entity;
+  protected __targetEntity?: Entity;
   public scaleOfLengthCenterToCamera = 1.0;
   private __scaleOfZNearAndZFar = 5000;
   private __doPreventDefault = true;
@@ -620,13 +620,10 @@ export default class OrbitCameraController extends AbstractCameraController impl
   }
 
   __updateCameraComponent(camera: CameraComponent) {
-    if (this.__targetEntity) {
-      const targetAABB = this.__targetEntity.getSceneGraph().worldAABB;;
-      const eyeDirection = OrbitCameraController.__tmpVec3_0.copyComponents(this.__newCenterVec)
-      eyeDirection.subtract(this.__newEyeVec).normalize();
-      this._calcZNearInner(camera, this.__newEyeVec, eyeDirection, targetAABB);
-      this._calcZFarInner(camera);
-    }
+    const eyeDirection = OrbitCameraController.__tmpVec3_0.copyComponents(this.__newCenterVec)
+    eyeDirection.subtract(this.__newEyeVec).normalize();
+    this._calcZNearInner(camera, this.__newEyeVec, eyeDirection);
+    this._calcZFarInner(camera);
 
     const ratio = camera.zFar / camera.zNear;
     const minRatio = this.__scaleOfZNearAndZFar;

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -92,8 +92,6 @@ export default class OrbitCameraController extends AbstractCameraController impl
 
   private static __tmpMat44_0: MutableMatrix44 = MutableMatrix44.identity();
 
-  private __firstTargetAABB?: AABB;
-
   constructor() {
     super();
     this.registerEventListeners();
@@ -519,7 +517,7 @@ export default class OrbitCameraController extends AbstractCameraController impl
       newEyeVec.copyComponents(eyeVec);
       newCenterVec.copyComponents(centerVec);
     } else {
-      const targetAABB = this.__getTargetAABB();
+      const targetAABB = this.__targetEntity.getSceneGraph().worldAABB;
 
       // calc newCenterVec
       newCenterVec.copyComponents(targetAABB.centerPoint);
@@ -623,7 +621,7 @@ export default class OrbitCameraController extends AbstractCameraController impl
 
   __updateCameraComponent(camera: CameraComponent) {
     if (this.__targetEntity) {
-      const targetAABB = this.__getTargetAABB();
+      const targetAABB = this.__targetEntity.getSceneGraph().worldAABB;;
       const eyeDirection = OrbitCameraController.__tmpVec3_0.copyComponents(this.__newCenterVec)
       eyeDirection.subtract(this.__newEyeVec).normalize();
       this._calcZNearInner(camera, this.__newEyeVec, eyeDirection, targetAABB);
@@ -650,14 +648,6 @@ export default class OrbitCameraController extends AbstractCameraController impl
     camera.topInner = newTop;
     camera.bottomInner = newBottom;
     camera.fovyInner = fovy;
-  }
-
-
-  __getTargetAABB() {
-    if (this.__firstTargetAABB == null) {
-      this.__firstTargetAABB = this.__targetEntity!.getSceneGraph().worldAABB.clone();
-    }
-    return this.__firstTargetAABB;
   }
 
   set scaleOfZNearAndZFar(value: number) {

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -545,14 +545,14 @@ export default class OrbitCameraController implements ICameraController {
 
       rotateM.multiplyVectorTo(this.__upVec, newUpVec);
       rotateM.multiplyVectorTo(centerToEyeVec, newEyeVec).add(this.__centerVec);
-      this.__newCenterVec.copyComponents(this.__centerVec);
+      newCenterVec.copyComponents(this.__centerVec);
 
       const newEyeToCenterVec = OrbitCameraController.__tmpVec3_1;
       MutableVector3.subtractTo(newCenterVec, newEyeVec, newEyeToCenterVec);
       MutableVector3.crossTo(newUpVec, newEyeToCenterVec, newTangentVec);
 
-      this.__newEyeVec.add(this.__mouseTranslateVec);
-      this.__newCenterVec.add(this.__mouseTranslateVec);
+      newEyeVec.add(this.__mouseTranslateVec);
+      newCenterVec.add(this.__mouseTranslateVec);
 
       // const horizonResetVec = OrbitCameraController.__tmpVec3_2;
       // rotateM_Reset.multiplyVectorTo(centerToEyeVec, horizonResetVec);
@@ -573,14 +573,14 @@ export default class OrbitCameraController implements ICameraController {
 
       rotateM.multiplyVectorTo(this.__upVec, newUpVec);
       rotateM.multiplyVectorTo(centerToEyeVec, newEyeVec).add(this.__centerVec);
-      this.__newCenterVec.copyComponents(this.__centerVec);
+      newCenterVec.copyComponents(this.__centerVec);
 
       const newEyeToCenterVec = OrbitCameraController.__tmpVec3_1;
       MutableVector3.subtractTo(newCenterVec, newEyeVec, newEyeToCenterVec);
       MutableVector3.crossTo(newUpVec, newEyeToCenterVec, newTangentVec);
 
-      this.__newEyeVec.add(this.__mouseTranslateVec);
-      this.__newCenterVec.add(this.__mouseTranslateVec);
+      newEyeVec.add(this.__mouseTranslateVec);
+      newCenterVec.add(this.__mouseTranslateVec);
     }
 
     let newLeft = camera.left;

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -391,25 +391,25 @@ export default class OrbitCameraController extends AbstractCameraController impl
   }
 
   __pressShift(e: KeyboardEvent) {
-    if (e.keyCode === 16) {
+    if (e.shiftKey === true) {
       this.__isPressingShift = true;
     }
   }
 
   __releaseShift(e: KeyboardEvent) {
-    if (e.keyCode === 16) {
+    if (e.shiftKey === false) {
       this.__isPressingShift = false;
     }
   }
 
   __pressCtrl(e: KeyboardEvent) {
-    if (e.keyCode === 17) {
+    if (e.ctrlKey === true) {
       this.__isPressingCtrl = true;
     }
   }
 
   __releaseCtrl(e: KeyboardEvent) {
-    if (e.keyCode === 17) {
+    if (e.ctrlKey === false) {
       this.__isPressingCtrl = false;
     }
   }

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -45,7 +45,6 @@ export default class OrbitCameraController extends AbstractCameraController impl
   private __upVec = MutableVector3.zero();
   private __targetEntity?: Entity;
   public scaleOfLengthCenterToCamera = 1.0;
-  private __zFarAdjustingFactorBasedOnAABB = 150;
   private __scaleOfZNearAndZFar = 5000;
   private __doPreventDefault = true;
   public moveSpeed = 1;
@@ -98,14 +97,6 @@ export default class OrbitCameraController extends AbstractCameraController impl
   constructor() {
     super();
     this.registerEventListeners();
-  }
-
-  set zFarAdjustingFactorBasedOnAABB(value: number) {
-    this.__zFarAdjustingFactorBasedOnAABB = value;
-  }
-
-  get zFarAdjustingFactorBasedOnAABB() {
-    return this.__zFarAdjustingFactorBasedOnAABB;
   }
 
   setTarget(targetEntity: Entity) {

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -504,11 +504,11 @@ export default class OrbitCameraController implements ICameraController {
   }
 
   logic(cameraComponent: CameraComponent) {
-    this.__updateTargeting(cameraComponent!);
-    this.__convert(cameraComponent);
+    this.__updateTargeting(cameraComponent);
+    this.__updateCameraComponent(cameraComponent);
   }
 
-  __convert(camera: CameraComponent) {
+  __updateCameraComponent(camera: CameraComponent) {
     const centerToEyeVec = this.__eyeVec.subtract(this.__centerVec);
     centerToEyeVec.multiply(this.__dolly * this.dollyScale);
 

--- a/src/foundation/cameras/OrbitCameraController.ts
+++ b/src/foundation/cameras/OrbitCameraController.ts
@@ -30,7 +30,6 @@ export default class OrbitCameraController implements ICameraController {
   private __newTangentVec = MutableVector3.zero();
   // private __verticalAngleThreshold = 0;
   // private __verticalAngleOfVectors = 0;
-  private __isForceGrab = false;
   private __isSymmetryMode = true;
   public eventTargetDom?: HTMLElement;
   // private __doResetWhenCameraSettingChanged = false;
@@ -532,11 +531,9 @@ export default class OrbitCameraController implements ICameraController {
   }
 
   __convert(camera: CameraComponent, eye: Vector3, center: Vector3, up: Vector3) {
-    if (this.__isKeyUp || !this.__isForceGrab) {
-      MutableVector3.addTo(eye, this.__shiftCameraTo, this.__eyeVec);
-      MutableVector3.addTo(center, this.__shiftCameraTo, this.__centerVec);
-      this.__upVec.copyComponents(up);
-    }
+    MutableVector3.addTo(eye, this.__shiftCameraTo, this.__eyeVec);
+    MutableVector3.addTo(center, this.__shiftCameraTo, this.__centerVec);
+    this.__upVec.copyComponents(up);
 
     const centerToEyeVec = this.__eyeVec.subtract(this.__centerVec);
     centerToEyeVec.multiply(this.__dolly * this.dollyScale);

--- a/src/foundation/cameras/WalkThroughCameraController.ts
+++ b/src/foundation/cameras/WalkThroughCameraController.ts
@@ -49,7 +49,6 @@ export default class WalkThroughCameraController extends AbstractCameraControlle
   private _needInitialize = true;
   private _targetEntity?: Entity;
   private _zFarAdjustingFactorBasedOnAABB = 150.0;
-  private __scaleOfZNearAndZFar = 5000;
 
   private static __tmpInvMat: MutableMatrix44 = MutableMatrix44.identity();
   private static __tmpRotateMat: MutableMatrix33 = MutableMatrix33.identity();
@@ -397,14 +396,6 @@ export default class WalkThroughCameraController extends AbstractCameraControlle
 
   get zFarAdjustingFactorBasedOnAABB() {
     return this._zFarAdjustingFactorBasedOnAABB;
-  }
-
-  set scaleOfZNearAndZFar(value: number) {
-    this.__scaleOfZNearAndZFar = value;
-  }
-
-  get scaleOfZNearAndZFar() {
-    return this.__scaleOfZNearAndZFar;
   }
 
   get allInfo() {

--- a/src/foundation/cameras/WalkThroughCameraController.ts
+++ b/src/foundation/cameras/WalkThroughCameraController.ts
@@ -224,11 +224,11 @@ export default class WalkThroughCameraController implements ICameraController {
   }
 
   logic(cameraComponent: CameraComponent) {
-    this.__convert(cameraComponent);
+    this.__updateCameraComponent(cameraComponent);
   }
 
 
-  private __convert(camera: CameraComponent) {
+  private __updateCameraComponent(camera: CameraComponent) {
     let newZNear = camera.zNearInner;
     let newZFar = camera.zFarInner;
 

--- a/src/foundation/cameras/WalkThroughCameraController.ts
+++ b/src/foundation/cameras/WalkThroughCameraController.ts
@@ -142,7 +142,7 @@ export default class WalkThroughCameraController extends AbstractCameraControlle
     }
   }
 
-  _mouseWheel(e: MouseWheelEvent) {
+  _mouseWheel(e: WheelEvent) {
     if (this._currentDir === null) {
       return;
     }

--- a/src/foundation/cameras/WalkThroughCameraController.ts
+++ b/src/foundation/cameras/WalkThroughCameraController.ts
@@ -224,18 +224,7 @@ export default class WalkThroughCameraController implements ICameraController {
   }
 
   logic(cameraComponent: CameraComponent) {
-    const data = this.__convert(cameraComponent);
-    const cc = cameraComponent;
-    cc.eyeInner = data.newEyeVec;
-    cc.directionInner = data.newCenterVec;
-    cc.upInner = data.newUpVec;
-    cc.zNearInner = data.newZNear;
-    cc.zFarInner = data.newZFar;
-    cc.leftInner = data.newLeft;
-    cc.rightInner = data.newRight;
-    cc.topInner = data.newTop;
-    cc.bottomInner = data.newBottom;
-    cc.fovyInner = data.fovy;
+    this.__convert(cameraComponent);
   }
 
 
@@ -269,6 +258,17 @@ export default class WalkThroughCameraController implements ICameraController {
 
       this._needInitialize = false;
     }
+
+    camera.eyeInner = this._currentPos;
+    camera.directionInner = this._currentCenter;
+    camera.upInner = (camera as any)._up;
+    camera.zNearInner = newZNear;
+    camera.zFarInner = newZFar;
+    camera.leftInner = camera.left;
+    camera.rightInner = camera.right;
+    camera.topInner = camera.top;
+    camera.bottomInner = camera.bottom;
+    camera.fovyInner = camera.fovy;
 
     const t = this._deltaY / 90;
     this._newDir.x = this._currentDir.x * (1 - t);
@@ -357,23 +357,6 @@ export default class WalkThroughCameraController implements ICameraController {
       this._deltaMouseYOnCanvas = 0;
     }
 
-    const newLeft = camera.left;
-    const newRight = camera.right;
-    const newTop = camera.top;
-    const newBottom = camera.bottom;
-
-    return {
-      newEyeVec: this._currentPos,
-      newCenterVec: this._currentCenter,
-      newUpVec: camera.up.clone(),
-      newZNear: newZNear,
-      newZFar: newZFar,
-      newLeft,
-      newRight,
-      newTop,
-      newBottom,
-      fovy: camera.fovy
-    };
   }
 
   getDirection() {

--- a/src/foundation/cameras/WalkThroughCameraController.ts
+++ b/src/foundation/cameras/WalkThroughCameraController.ts
@@ -47,7 +47,7 @@ export default class WalkThroughCameraController extends AbstractCameraControlle
   private _mouseWheelBind = (this._mouseWheel as any).bind(this);
   private _eventTargetDom?: any;
   private _needInitialize = true;
-  private _targetEntity?: Entity;
+  protected __targetEntity?: Entity;
   private _zFarAdjustingFactorBasedOnAABB = 150.0;
 
   private static __tmpInvMat: MutableMatrix44 = MutableMatrix44.identity();
@@ -228,7 +228,7 @@ export default class WalkThroughCameraController extends AbstractCameraControlle
   }
 
   private __updateCameraComponent(camera: CameraComponent) {
-    const targetAABB = this._targetEntity?.getSceneGraph().worldAABB;
+    const targetAABB = this.__targetEntity?.getSceneGraph().worldAABB;
     if (this._needInitialize && targetAABB != null) {
       const lengthCenterToCamera =
         targetAABB.lengthCenterToCorner * (1.0 + 1.0 / Math.tan(MathUtil.degreeToRadian(camera.fovy / 2.0)));
@@ -344,10 +344,8 @@ export default class WalkThroughCameraController extends AbstractCameraControlle
     camera.bottomInner = camera.bottom;
     camera.fovyInner = camera.fovy;
 
-    if (targetAABB != null) {
-      this._calcZNearInner(camera, this._currentPos, this._newDir, targetAABB);
-      this._calcZFarInner(camera);
-    }
+    this._calcZNearInner(camera, this._currentPos, this._newDir);
+    this._calcZFarInner(camera);
   }
   getDirection() {
     return this._currentCenter !== null ? this._newDir.clone() : null;
@@ -382,12 +380,12 @@ export default class WalkThroughCameraController extends AbstractCameraControlle
     this.verticalSpeed = speed;
     this.horizontalSpeed = speed;
 
-    this._targetEntity = targetEntity;
+    this.__targetEntity = targetEntity;
     this._needInitialize = true;
   }
 
   getTarget(): Entity | undefined {
-    return this._targetEntity;
+    return this.__targetEntity;
   }
 
   set zFarAdjustingFactorBasedOnAABB(value: number) {


### PR DESCRIPTION
If a user attaches the camera controller component to an entity that has the camera component, the original z near and z far are ignored and the camera component adopts the calculated value by the camera controller. The calculation method of them is different between the orbit type and the walkthrough type.

Here, there are problems.
1. When a user attaches the camera controller component, the user cannot control z near and z far manually.
2. If a user changes the camera controller type, some objects appear/disappear on the display because z near and far are different between camera controller types.

To improve them, I created an abstract class of camera controller classes. The abstract class has the following:
1. The flag of the auto calculation of z near and z far
2. A calculation method of z near and far

If the flag of the 1, we can apply z near and z far manually. We can unify the calculation method of z near and z far by the method of the 2.

For the calculation of z near and z far, I adopt the following method:
- z near: The maximum value of the following 2 values:
1. (length AABB centre to eye) * cos((the angle between camera direction) and (camera to AABB centre)) - (length of AABB centre to corner)
The below is a reference image of this equation:

![zNear](https://user-images.githubusercontent.com/7972283/99328064-b0339580-28be-11eb-8c9c-5158526af717.PNG)

2. (min(side length of the AABB) / 2 ) / user-set value (default is 10)

- z far: (calculated z near) * (user-set value (default is 10000))