### PR TITLE
Resize non-power of two texture to power of two size in webGL1.0

### DIFF
--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -631,9 +631,8 @@ export default class ModelConverter {
         const webglResourceRepository = CGAPIResourceRepository.getWebGLResourceRepository();
         const isWebGL1 = !webglResourceRepository.currentWebGLContextWrapper?.isWebGL2;
 
-        if (isWebGL1 && !this.__sizeIsPowerOfTwo(image.image)) {
-          textureOption.wrapS = TextureParameter.ClampToEdge;
-          textureOption.wrapT = TextureParameter.ClampToEdge;
+        if (isWebGL1 && !this.__sizeIsPowerOfTwo(image.image) && this.__needResizeToPowerOfTwoOnWebGl1(textureOption)) {
+          rnTexture.autoResize = true;
         }
 
         rnTexture.generateTextureFromImage(image.image, textureOption);
@@ -920,9 +919,8 @@ export default class ModelConverter {
       const webglResourceRepository = CGAPIResourceRepository.getWebGLResourceRepository();
       const isWebGL1 = !webglResourceRepository.currentWebGLContextWrapper?.isWebGL2;
 
-      if (isWebGL1 && !this.__sizeIsPowerOfTwo(image)) {
-        textureOption.wrapS = TextureParameter.ClampToEdge;
-        textureOption.wrapT = TextureParameter.ClampToEdge;
+      if (isWebGL1 && !this.__sizeIsPowerOfTwo(image) && this.__needResizeToPowerOfTwoOnWebGl1(textureOption)) {
+        rnTexture.autoResize = true;
       }
 
       rnTexture.generateTextureFromImage(image, textureOption);
@@ -943,6 +941,19 @@ export default class ModelConverter {
     }
 
     return rnTexture;
+  }
+
+  private static __needResizeToPowerOfTwoOnWebGl1(textureOption: any) {
+    if (
+      textureOption.wrapS !== TextureParameter.ClampToEdge ||
+      textureOption.wrapT !== TextureParameter.ClampToEdge ||
+      (textureOption.minFilter !== TextureParameter.Linear &&
+        textureOption.minFilter !== TextureParameter.Nearest)
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   private static __sizeIsPowerOfTwo(image: HTMLImageElement) {


### PR DESCRIPTION
I changed the behaviour of the ModelConverter class when a GlTF contains a non-power of two texture.

From the specification of the GlTF2.0, when a GlTF contains a non-power of two size texture and the sampler of the texture specifies the following parameters, the engine needs to resize the texture to the power of two size:
- The wrapping mode is REPEAT or MIRRORED_REPEAT.
- The minification filter (minFilter) is NEAREST_MIPMAP_NEAREST, NEAREST_MIPMAP_LINEAR, LINEAR_MIPMAP_NEAREST, or LINEAR_MIPMAP_LINEAR.

I changed the Rhodonite to support it.