### PR TITLE
Fix min and max calculation in accessor interleaved model

### DIFF
--- a/src/foundation/components/SceneGraphComponent.ts
+++ b/src/foundation/components/SceneGraphComponent.ts
@@ -226,19 +226,18 @@ export default class SceneGraphComponent extends Component {
   }
 
   calcWorldAABB() {
-    const that = this;
     // this.__worldAABB.initialize();
     var aabb = (function mergeAABBRecursively(elem: SceneGraphComponent, flg: boolean): AABB {
       const meshComponent = elem.entity.getMesh();
 
       elem.__worldAABB.initialize();
-      if (meshComponent != null && meshComponent.mesh != null) {
-        const skeletalComponent = elem.entity.getSkeletal();
-        if (false) {//skeletalComponent) {
-          // AABB.multiplyMatrixTo(skeletalComponent.rootJointWorldMatrixInner as any as Matrix44, meshComponent.mesh.AABB, elem.__worldAABB);
-        } else {
-          AABB.multiplyMatrixTo(elem.worldMatrixInner as any as Matrix44, meshComponent.mesh.AABB, elem.__worldAABB);
-        }
+      if (meshComponent?.mesh != null) {
+        // const skeletalComponent = elem.entity.getSkeletal();
+        // if (false) {//skeletalComponent) {
+        //   // AABB.multiplyMatrixTo(skeletalComponent.rootJointWorldMatrixInner as any as Matrix44, meshComponent.mesh.AABB, elem.__worldAABB);
+        // } else {
+        AABB.multiplyMatrixTo(elem.worldMatrixInner, meshComponent.mesh.AABB, elem.__worldAABB);
+        // }
       }
 
       var children = elem.children;

--- a/src/foundation/geometry/Primitive.ts
+++ b/src/foundation/geometry/Primitive.ts
@@ -34,6 +34,8 @@ export default class Primitive extends RnObject {
   private __inverseArenbergMatrix: Matrix33[] = [];
   private __arenberg3rdPosition: Vector3[] = [];
 
+  private static __tmpVec3_0: MutableVector3 = MutableVector3.zero();
+
   constructor() {
     super();
   }
@@ -299,8 +301,11 @@ export default class Primitive extends RnObject {
       if (positionAccessor.min == null || positionAccessor.max == null) {
         positionAccessor.calcMinMax();
       }
-      this.__aabb.minPoint = positionAccessor.min;
-      this.__aabb.maxPoint = positionAccessor.max;
+
+      const min = positionAccessor.min as number[];
+      this.__aabb.minPoint = Primitive.__tmpVec3_0.setComponents(min[0], min[1], min[2]);
+      const max = positionAccessor.max as number[];
+      this.__aabb.maxPoint = Primitive.__tmpVec3_0.setComponents(max[0], max[1], max[2]);
     }
 
     return this.__aabb;

--- a/src/foundation/math/AABB.ts
+++ b/src/foundation/math/AABB.ts
@@ -37,7 +37,7 @@ export default class AABB {
   }
 
   set minPoint(val: Vector3) {
-    this.__min = new MutableVector3(val);
+    this.__min.copyComponents(val);
     this.__isCenterPointDirty = true;
     this.__isLengthCenterToCornerDirty = true;
   }
@@ -47,7 +47,7 @@ export default class AABB {
   }
 
   set maxPoint(val: Vector3) {
-    this.__max = new MutableVector3(val);
+    this.__max.copyComponents(val);
     this.__isCenterPointDirty = true;
     this.__isLengthCenterToCornerDirty = true;
   }

--- a/src/foundation/memory/Accessor.ts
+++ b/src/foundation/memory/Accessor.ts
@@ -6,12 +6,12 @@ import { Count, Byte, Size } from "../../commontypes/CommonTypes";
 
 
 export default class Accessor extends AccessorBase {
-  constructor({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, arrayLength, normalized }:
+  constructor({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, max, min, arrayLength, normalized }:
     {
       bufferView: BufferView, byteOffset: Byte, byteOffsetFromBuffer: Byte, compositionType: CompositionTypeEnum,
-      componentType: ComponentTypeEnum, byteStride: Byte, count: Count, raw: ArrayBuffer, arrayLength: Size, normalized: boolean
+      componentType: ComponentTypeEnum, byteStride: Byte, count: Count, raw: ArrayBuffer, max: number[], min: number[], arrayLength: Size, normalized: boolean
     }) {
-    super({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, arrayLength, normalized });
+    super({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, max, min, arrayLength, normalized });
 
   }
 }

--- a/src/foundation/memory/AccessorBase.ts
+++ b/src/foundation/memory/AccessorBase.ts
@@ -32,7 +32,7 @@ export default class AccessorBase extends RnObject {
   constructor({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, max, min, arrayLength, normalized }:
     {
       bufferView: BufferView, byteOffset: Byte, compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum,
-      byteStride: Byte, count: Count, raw: ArrayBuffer, max?: number, min?: number, arrayLength: Size, normalized: boolean
+      byteStride: Byte, count: Count, raw: ArrayBuffer, max?: number[], min?: number[], arrayLength: Size, normalized: boolean
     }) {
     super();
 

--- a/src/foundation/memory/AccessorBase.ts
+++ b/src/foundation/memory/AccessorBase.ts
@@ -167,7 +167,7 @@ export default class AccessorBase extends RnObject {
   }
 
   get elementCount(): Count {
-    return this.__dataView!.byteLength / (this.numberOfComponents * this.componentSizeInBytes);
+    return this.__count;
   }
 
   get byteLength(): Byte {

--- a/src/foundation/memory/AccessorBase.ts
+++ b/src/foundation/memory/AccessorBase.ts
@@ -24,8 +24,8 @@ export default class AccessorBase extends RnObject {
   protected __typedArrayClass?: TypedArrayConstructor;
   protected __dataViewGetter: any;
   protected __dataViewSetter: any;
-  protected __max?: any;
-  protected __min?: any;
+  protected __max?: number[];
+  protected __min?: number[];
   protected __arrayLength = 1;
   protected __normalized: boolean = false;
 
@@ -42,15 +42,10 @@ export default class AccessorBase extends RnObject {
     this.__componentType = componentType;
     this.__count = count;
     this.__arrayLength = arrayLength;
+    this.__max = max;
+    this.__min = min;
     this.__raw = raw;
     this.__normalized = normalized;
-
-    if (max != null) {
-      this.__max = max;
-    }
-    if (min != null) {
-      this.__min = min;
-    }
 
     this.__byteStride = byteStride;
 
@@ -608,8 +603,8 @@ export default class AccessorBase extends RnObject {
           max = scalar;
         }
       }
-      this.__min = min;
-      this.__max = max;
+      this.__min = [min];
+      this.__max = [max];
     }
   }
 }

--- a/src/foundation/memory/AccessorBase.ts
+++ b/src/foundation/memory/AccessorBase.ts
@@ -76,7 +76,7 @@ export default class AccessorBase extends RnObject {
       if (this.__raw.byteLength - this.__byteOffsetInRawArrayBufferOfBuffer < this.__compositionType.getNumberOfComponents() * this.__componentType.getSizeInBytes() * this.__count) {
         console.error(`Requesting a data size that exceeds the remaining capacity of the buffer: ${this.bufferView.buffer.name}.`);
       }
-      this.__dataView = new DataView(this.__raw, this.__byteOffsetInRawArrayBufferOfBuffer, this.__compositionType.getNumberOfComponents() * this.__componentType.getSizeInBytes() * this.__count);
+      this.__dataView = new DataView(this.__raw, this.__byteOffsetInRawArrayBufferOfBuffer, this.__byteStride * this.__count);
     } else {
       this.__dataView = new DataView(this.__raw, this.__byteOffsetInRawArrayBufferOfBuffer);
     }

--- a/src/foundation/memory/BufferView.ts
+++ b/src/foundation/memory/BufferView.ts
@@ -91,7 +91,7 @@ export default class BufferView extends RnObject {
   takeAccessor({ compositionType, componentType, count, max, min, byteAlign = 4, arrayLength, normalized = false }:
     {
       compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, count: Count,
-      max?: number, min?: number, byteAlign?: Byte, arrayLength?: Size, normalized?: boolean
+      max?: number[], min?: number[], byteAlign?: Byte, arrayLength?: Size, normalized?: boolean
     }): Accessor {
 
     const byteStride = this.byteStride;
@@ -108,7 +108,7 @@ export default class BufferView extends RnObject {
   takeFlexibleAccessor({ compositionType, componentType, count, byteStride, max, min, byteAlign = 4, arrayLength, normalized = false }:
     {
       compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, count: Count,
-      byteStride: Byte, max?: number, min?: number, byteAlign?: Byte, arrayLength?: Size, normalized?: boolean
+      byteStride: Byte, max?: number[], min?: number[], byteAlign?: Byte, arrayLength?: Size, normalized?: boolean
     }): FlexibleAccessor {
 
     const _arrayLength = (arrayLength != null) ? arrayLength : 1;
@@ -124,7 +124,7 @@ export default class BufferView extends RnObject {
   takeAccessorWithByteOffset({ compositionType, componentType, count, byteOffset, max, min, normalized = false }:
     {
       compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, count: Count,
-      byteOffset: Byte, max?: number, min?: number, normalized?: boolean
+      byteOffset: Byte, max?: number[], min?: number[], normalized?: boolean
     }): Accessor {
     const byteStride = this.byteStride;
 
@@ -138,7 +138,7 @@ export default class BufferView extends RnObject {
   takeFlexibleAccessorWithByteOffset({ compositionType, componentType, count, byteStride, byteOffset, max, min, normalized = false }:
     {
       compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, count: Count, byteStride: Byte,
-      byteOffset: Byte, max?: number, min?: number, normalized?: boolean
+      byteOffset: Byte, max?: number[], min?: number[], normalized?: boolean
     }): FlexibleAccessor {
 
     const accessor = this.__takeAccessorInnerWithByteOffset({
@@ -151,7 +151,7 @@ export default class BufferView extends RnObject {
   private __takeAccessorInner({ compositionType, componentType, count, byteStride, accessorClass, max, min, byteAlign, arrayLength, normalized }:
     {
       compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, count: Count, byteStride: Byte,
-      accessorClass: any, max?: number, min?: number, byteAlign: Byte, arrayLength: Size, normalized: boolean
+      accessorClass: any, max?: number[], min?: number[], byteAlign: Byte, arrayLength: Size, normalized: boolean
     }): AccessorBase {
 
     let byteOffset = 0;
@@ -199,7 +199,7 @@ export default class BufferView extends RnObject {
   private __takeAccessorInnerWithByteOffset({ compositionType, componentType, count, byteStride, byteOffset, accessorClass, max, min, normalized }:
     {
       compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, count: Count, byteStride: Byte,
-      byteOffset: Byte, accessorClass: any, max?: number, min?: number, normalized: boolean
+      byteOffset: Byte, accessorClass: any, max?: number[], min?: number[], normalized: boolean
     }): AccessorBase {
 
     // if (byteOffset % 4 !== 0) {

--- a/src/foundation/memory/FlexibleAccessor.ts
+++ b/src/foundation/memory/FlexibleAccessor.ts
@@ -6,12 +6,12 @@ import { Count, Byte, Size } from "../../commontypes/CommonTypes";
 
 
 export default class FlexibleAccessor extends AccessorBase {
-  constructor({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, arrayLength, normalized }:
+  constructor({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, max, min, arrayLength, normalized }:
     {
       bufferView: BufferView, byteOffset: Byte, byteOffsetFromBuffer: Byte, compositionType: CompositionTypeEnum,
-      componentType: ComponentTypeEnum, byteStride: Byte, count: Count, raw: ArrayBuffer, arrayLength: Size, normalized: boolean
+      componentType: ComponentTypeEnum, byteStride: Byte, count: Count, raw: ArrayBuffer, max: number[], min: number[], arrayLength: Size, normalized: boolean
     }) {
-    super({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, arrayLength, normalized });
+    super({ bufferView, byteOffset, compositionType, componentType, byteStride, count, raw, max, min, arrayLength, normalized });
   }
 }
 


### PR DESCRIPTION
This PR fixes #637.

I fixed the following:
1. In the constructor of accessorClasses does not take a min and a max property.
2. When the accessor is interleaved(multiple accessor share single bufferView), the byte length of the dataView in an accessor is strange.
3. When the accessor is interleaved, element count in an accessor is strange.