### PR TITLE
Support normal scale and occlusion strength

### DIFF
--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -858,6 +858,9 @@ export default class ModelConverter {
         if (occlusionTexture.texCoord != null) {
           material.setParameter(PbrShadingSingleMaterialNode.OcclusionTexcoordIndex, occlusionTexture.texCoord);
         }
+        if (occlusionTexture.strength != null) {
+          material.setParameter(PbrShadingSingleMaterialNode.OcclusionStrength, occlusionTexture.strength);
+        }
       }
 
       let metallicFactor = pbrMetallicRoughness.metallicFactor;

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -940,8 +940,14 @@ export default class ModelConverter {
     if (normalTexture != null) {
       const rnTexture = ModelConverter._createTexture(normalTexture, gltfModel)
       material.setTextureParameter(ShaderSemantics.NormalTexture, rnTexture);
-      if (parseFloat(gltfModel.asset?.version!) >= 2 && normalTexture.texCoord != null) {
-        material.setParameter(PbrShadingSingleMaterialNode.NormalTexcoordIndex, normalTexture.texCoord);
+      if (parseFloat(gltfModel.asset?.version!) >= 2) {
+        if (normalTexture.texCoord != null) {
+          material.setParameter(PbrShadingSingleMaterialNode.NormalTexcoordIndex, normalTexture.texCoord);
+        }
+
+        if (normalTexture.scale != null) {
+          material.setParameter(PbrShadingSingleMaterialNode.NormalScale, normalTexture.scale);
+        }
       }
     }
     ModelConverter._setupTextureTransform(normalTexture, material, PbrShadingSingleMaterialNode.NormalTextureTransform, PbrShadingSingleMaterialNode.NormalTextureRotation);

--- a/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
+++ b/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
@@ -38,6 +38,7 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
   static readonly OcclusionTexcoordIndex = new ShaderSemanticsClass({ str: 'occlusionTexcoordIndex' });
   static readonly EmissiveTexcoordIndex = new ShaderSemanticsClass({ str: 'emissiveTexcoordIndex' });
   static readonly NormalScale = new ShaderSemanticsClass({ str: 'normalScale' });
+  static readonly OcclusionStrength = new ShaderSemanticsClass({ str: 'occlusionStrength' });
 
   constructor({ isMorphing, isSkinning, isLighting, useTangentAttribute, useNormalTexture, alphaMode }: { isMorphing: boolean, isSkinning: boolean, isLighting: boolean, useTangentAttribute: boolean, useNormalTexture: boolean, alphaMode: AlphaModeEnum }) {
     super(null, 'pbrShading'
@@ -131,6 +132,11 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
         {
           semantic: PbrShadingSingleMaterialNode.EmissiveTexcoordIndex, compositionType: CompositionType.Scalar, componentType: ComponentType.Int,
           stage: ShaderType.PixelShader, min: 0, max: 1, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
+        },
+
+        {
+          semantic: PbrShadingSingleMaterialNode.OcclusionStrength, compositionType: CompositionType.Scalar, componentType: ComponentType.Float,
+          stage: ShaderType.PixelShader, min: 0, max: 1, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(1)
         }
       ];
 

--- a/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
+++ b/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
@@ -37,6 +37,7 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
   static readonly MetallicRoughnessTexcoordIndex = new ShaderSemanticsClass({ str: 'metallicRoughnessTexcoordIndex' });
   static readonly OcclusionTexcoordIndex = new ShaderSemanticsClass({ str: 'occlusionTexcoordIndex' });
   static readonly EmissiveTexcoordIndex = new ShaderSemanticsClass({ str: 'emissiveTexcoordIndex' });
+  static readonly NormalScale = new ShaderSemanticsClass({ str: 'normalScale' });
 
   constructor({ isMorphing, isSkinning, isLighting, useTangentAttribute, useNormalTexture, alphaMode }: { isMorphing: boolean, isSkinning: boolean, isLighting: boolean, useTangentAttribute: boolean, useNormalTexture: boolean, alphaMode: AlphaModeEnum }) {
     super(null, 'pbrShading'
@@ -199,6 +200,10 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
         {
           semantic: PbrShadingSingleMaterialNode.NormalTexcoordIndex, compositionType: CompositionType.Scalar, componentType: ComponentType.Int,
           stage: ShaderType.PixelShader, min: 0, max: 1, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
+        },
+        {
+          semantic: PbrShadingSingleMaterialNode.NormalScale, compositionType: CompositionType.Scalar, componentType: ComponentType.Float,
+          stage: ShaderType.PixelShader, min: 0, max: Number.MAX_SAFE_INTEGER, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(1)
         }
       );
     }

--- a/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
+++ b/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
@@ -257,9 +257,10 @@ void main ()
   int occlusionTexcoordIndex = get_occlusionTexcoordIndex(materialSID, 0);
   vec2 occlusionTexcoord = getTexcoord(occlusionTexcoordIndex);
   float occlusion = texture2D(u_occlusionTexture, occlusionTexcoord).r;
+  float occlusionStrength = get_occlusionStrength(materialSID, 0);
 
   // Occlution to Indirect Lights
-  rt0.xyz += ibl * occlusion;
+  rt0.xyz += mix(ibl, ibl * occlusion, occlusionStrength);
 #else
   rt0 = vec4(baseColor, alpha);
 #endif

--- a/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
+++ b/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
@@ -122,7 +122,9 @@ void main ()
     if(normalTexValue.b >= 128.0 / 255.0) {
       // normal texture is existence
       vec3 normalTex = normalTexValue * 2.0 - 1.0;
-      normal_inWorld = perturb_normal(normal_inWorld, viewVector, normalTexUv, normalTex);
+      float normalScale = get_normalScale(materialSID, 0);
+      vec3 scaledNormal = normalize(normalTex * vec3(normalScale, normalScale, 1.0));
+      normal_inWorld = perturb_normal(normal_inWorld, viewVector, normalTexUv, scaledNormal);
     }
   #endif
 


### PR DESCRIPTION
This PR supports normalTextureInfo.scale and occlusionTextureInfo.strength property in GTF2.0.

Supporting normalTextureInfo.scale fixes #612.