### PR TITLE
Tangent calculation in shader

### DIFF
--- a/src/foundation/geometry/Mesh.ts
+++ b/src/foundation/geometry/Mesh.ts
@@ -38,7 +38,18 @@ export default class Mesh {
   public _attachedEntityUID = Entity.invalidEntityUID;
   private __instancesDirty = true;
   private static __originalMeshes: Mesh[] = [];
-  public tangentCalculationMode: Index = 1; // 0: Off, 1: auto, 2: force calculation
+
+  /**
+   * TODO: implementation of the following modes.
+   * Specification of when calculate the tangent of a vertex to apply Normal texture (for pbr/MToon shader)
+   * 0: Not calculate tangent (not apply normal texture)
+   * 1: (default) Use original tangent in a vertex, if a vertex has tangent attribute. If a vertex does not have it, calculate a tangent in a shader.
+   * 2: Use original tangent in a vertex, if a vertex has tangent attribute. If a vertex does not have it, precalculate a tangent in the javascript.
+   * 3: Calculate all tangent in a shader.
+   * 4: Precalculate all tangent in the javascript
+   */
+  public tangentCalculationMode: Index = 1;
+
   public isPreComputeForRayCastPickingEnable: boolean = false;
   private __hasFaceNormal = false;
 

--- a/src/foundation/geometry/Mesh.ts
+++ b/src/foundation/geometry/Mesh.ts
@@ -40,7 +40,6 @@ export default class Mesh {
   private static __originalMeshes: Mesh[] = [];
 
   /**
-   * TODO: implementation of the following modes.
    * Specification of when calculate the tangent of a vertex to apply Normal texture (for pbr/MToon shader)
    * 0: Not calculate tangent (not apply normal texture)
    * 1: (default) Use original tangent in a vertex, if a vertex has tangent attribute. If a vertex does not have it, calculate a tangent in a shader.
@@ -236,12 +235,12 @@ export default class Mesh {
   }
 
   __calcTangents() {
-    if (this.tangentCalculationMode === 0 || this.isInstanceMesh()) {
+    if (!this.__usePreCalculatedTangent()) {
       return;
     }
     for (let primitive of this.__primitives) {
       const tangentIdx = primitive.attributeSemantics.indexOf(VertexAttribute.Tangent);
-      if (tangentIdx !== -1 && this.tangentCalculationMode === 1) {
+      if (tangentIdx !== -1 && this.tangentCalculationMode === 2) {
         continue;
       }
       const texcoordIdx = primitive.attributeSemantics.indexOf(VertexAttribute.Texcoord0);
@@ -282,7 +281,7 @@ export default class Mesh {
     }
   }
 
-  __calcTangentFor3Vertices(
+  private __calcTangentFor3Vertices(
     i: Index,
     pos0: Vector3,
     pos1: Vector3,
@@ -303,7 +302,7 @@ export default class Mesh {
     tangentAccessor.setVec4(i + 2, tan2Vec3.x, tan2Vec3.y, tan2Vec3.z, 1, { indicesAccessor });
   }
 
-  __calcTangentPerVertex(
+  private __calcTangentPerVertex(
     pos0Vec3: Vector3,
     pos1Vec3: Vector3,
     pos2Vec3: Vector3,
@@ -356,6 +355,19 @@ export default class Mesh {
     }
 
     return returnVec3.setComponents(u[0], u[1], u[2]).normalize() as Vector3;
+  }
+
+  private __usePreCalculatedTangent() {
+    if (
+      this.tangentCalculationMode === 0 ||
+      this.tangentCalculationMode === 1 ||
+      this.tangentCalculationMode === 3 ||
+      this.isInstanceMesh()
+    ) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   getPrimitiveAt(i: number): Primitive {

--- a/src/foundation/helpers/MaterialHelper.ts
+++ b/src/foundation/helpers/MaterialHelper.ts
@@ -46,7 +46,7 @@ function createEmptyMaterial() {
 }
 
 function createPbrUberMaterial({
-  additionalName = '', isMorphing = false, isSkinning = false, isLighting = false, useTangentAttribute = false, alphaMode = AlphaMode.Opaque,
+  additionalName = '', isMorphing = false, isSkinning = false, isLighting = false, useTangentAttribute = false, useNormalTexture = true, alphaMode = AlphaMode.Opaque,
   maxInstancesNumber = Config.maxMaterialInstanceForEachType
 } = {}) {
   const materialName = 'PbrUber'
@@ -57,7 +57,7 @@ function createPbrUberMaterial({
     + (useTangentAttribute ? '+tangentAttribute' : '')
     + ' alpha_' + alphaMode.str.toLowerCase();
 
-  const materialNode = new PbrShadingSingleMaterialNode({ isMorphing, isSkinning, isLighting, useTangentAttribute, alphaMode });
+  const materialNode = new PbrShadingSingleMaterialNode({ isMorphing, isSkinning, isLighting, useTangentAttribute, useNormalTexture, alphaMode });
 
   materialNode.isSingleOperation = true;
   const material = createMaterial(materialName, [materialNode], maxInstancesNumber);

--- a/src/foundation/helpers/MaterialHelper.ts
+++ b/src/foundation/helpers/MaterialHelper.ts
@@ -46,7 +46,7 @@ function createEmptyMaterial() {
 }
 
 function createPbrUberMaterial({
-  additionalName = '', isMorphing = false, isSkinning = false, isLighting = false, alphaMode = AlphaMode.Opaque,
+  additionalName = '', isMorphing = false, isSkinning = false, isLighting = false, useTangentAttribute = false, alphaMode = AlphaMode.Opaque,
   maxInstancesNumber = Config.maxMaterialInstanceForEachType
 } = {}) {
   const materialName = 'PbrUber'
@@ -54,9 +54,10 @@ function createPbrUberMaterial({
     + (isMorphing ? '+morphing' : '')
     + (isSkinning ? '+skinning' : '')
     + (isLighting ? '' : '-lighting')
+    + (useTangentAttribute ? '+tangentAttribute' : '')
     + ' alpha_' + alphaMode.str.toLowerCase();
 
-  const materialNode = new PbrShadingSingleMaterialNode({ isMorphing, isSkinning, isLighting, alphaMode });
+  const materialNode = new PbrShadingSingleMaterialNode({ isMorphing, isSkinning, isLighting, useTangentAttribute, alphaMode });
 
   materialNode.isSingleOperation = true;
   const material = createMaterial(materialName, [materialNode], maxInstancesNumber);
@@ -173,7 +174,7 @@ function createEntityUIDOutputMaterial({ additionalName = '', maxInstancesNumber
 }
 
 function createMToonMaterial({
-  additionalName = '', isMorphing = false, isSkinning = false, isLighting = true,
+  additionalName = '', isMorphing = false, isSkinning = false, isLighting = true, useTangentAttribute = false,
   isOutline = false, materialProperties = undefined, textures = undefined, debugMode = undefined,
   maxInstancesNumber = Config.maxMaterialInstanceForEachType
 } = {}) {
@@ -182,9 +183,10 @@ function createMToonMaterial({
     + (isMorphing ? '+morphing' : '')
     + (isSkinning ? '+skinning' : '')
     + (isLighting ? '-lighting' : '')
+    + (useTangentAttribute ? '+tangentAttribute' : '')
     + (isOutline ? '-outline' : '');
 
-  const materialNode = new MToonSingleMaterialNode(isOutline, materialProperties, textures, isMorphing, isSkinning, isLighting, debugMode);
+  const materialNode = new MToonSingleMaterialNode(isOutline, materialProperties, textures, isMorphing, isSkinning, isLighting, useTangentAttribute, debugMode);
 
   materialNode.isSingleOperation = true;
   const material = createMaterial(materialName, [materialNode], maxInstancesNumber);

--- a/src/foundation/importer/GltfImporter.ts
+++ b/src/foundation/importer/GltfImporter.ts
@@ -236,11 +236,11 @@ export default class GltfImporter {
     const gltf2Importer = Gltf2Importer.getInstance();
     return gltf2Importer.importArrayBuffer(uri, file, options).then((gltfModel) => {
 
-      const textures = this._createTextures(gltfModel);
       const defaultMaterialHelperArgumentArray = gltfModel.asset.extras.rnLoaderOptions.defaultMaterialHelperArgumentArray;
-      defaultMaterialHelperArgumentArray[0].textures = textures;
+      defaultMaterialHelperArgumentArray[0].textures = defaultMaterialHelperArgumentArray[0].textures ?? this._createTextures(gltfModel);
+      defaultMaterialHelperArgumentArray[0].isLighting = defaultMaterialHelperArgumentArray[0].isLighting ?? true;
 
-      this._initializeMaterialProperties(gltfModel, textures.length);
+      this._initializeMaterialProperties(gltfModel, defaultMaterialHelperArgumentArray[0].length);
 
       let rootGroup;
       const modelConverter = ModelConverter.getInstance();

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -747,8 +747,9 @@ export default class ModelConverter {
     const additionalName = (node.skin != null) ? `skin${(node.skinIndex ?? node.skinName)}` : void 0;
     if (parseFloat(gltfModel.asset?.version!) >= 2) {
       const useTangentAttribute = this.__useTangentAttribute(gltfModel, primitive);
+      const useNormalTexture = this.__useNormalTexture(gltfModel);
       return MaterialHelper.createPbrUberMaterial({
-        isMorphing, isSkinning, isLighting, alphaMode, useTangentAttribute,
+        isMorphing, isSkinning, isLighting, alphaMode, useTangentAttribute, useNormalTexture,
         additionalName: additionalName, maxInstancesNumber: maxMaterialInstanceNumber
       });
     } else {
@@ -800,6 +801,14 @@ export default class ModelConverter {
       }
     }
     return false;
+  }
+  private __useNormalTexture(gltfModel: glTF2) {
+    const argument = gltfModel?.asset?.extras?.rnLoaderOptions?.defaultMaterialHelperArgumentArray[0];
+    if (argument?.useNormalTexture === false) {
+      return false;
+    } else {
+      return gltfModel?.asset?.extras?.rnLoaderOptions?.tangentCalculationMode !== 0;
+    }
   }
 
   private __getMaterialHash(node: Gltf2Node, gltfModel: glTF2, primitive: Gltf2Primitive, materialJson: any) {

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -150,7 +150,7 @@ export default class ModelConverter {
     }
 
     if (gltfModel.asset.extras && gltfModel.asset.extras.rnLoaderOptions) {
-    let options = gltfModel.asset.extras!.rnLoaderOptions;
+      let options = gltfModel.asset.extras!.rnLoaderOptions;
       if (options && options.loaderExtension && options?.loaderExtension?.loadExtensionInfoAndSetToRootGroup) {
         options.loaderExtension.loadExtensionInfoAndSetToRootGroup(rootGroup, gltfModel);
       }

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -779,8 +779,19 @@ export default class ModelConverter {
 
   private __useTangentAttribute(gltfModel: glTF2, primitive: Gltf2Primitive) {
     const tangentCalculationMode = gltfModel?.asset?.extras?.rnLoaderOptions?.tangentCalculationMode;
-    if (tangentCalculationMode === 2) {
-      true;
+
+    switch (tangentCalculationMode) {
+      case 0: // do not use normal map
+        return false;
+      case 1: // tangent attribute + calculated tangent in shader
+        break;
+      case 2: // tangent attribute + pre-calculated tangent
+        return true;
+      case 3: // force calc in shader
+        return false;
+      case 4: // force pre-calc
+        return true;
+      default:
     }
 
     for (const attribute in primitive.attributes) {

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -479,6 +479,10 @@ export default class Material extends RnObject {
     if (glw.webgl1ExtDRV) {
       definitions += '#define WEBGL1_EXT_STANDARD_DERIVATIVES\n';
     }
+
+    if (glw.isWebGL2 || glw.webgl1ExtDRV) {
+      definitions += '#define RN_IS_SUPPORTING_STANDARD_DERIVATIVES\n';
+    }
     if (Config.boneDataType === BoneDataType.Mat4x4) {
       definitions += '#define RN_BONE_DATA_TYPE_MAT4X4\n';
     } else if (Config.boneDataType === BoneDataType.Vec4x2) {

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -22,6 +22,7 @@ import { ProcessApproach } from "../../definitions/ProcessApproach";
 import ShaderityUtility from "./ShaderityUtility";
 import { BoneDataType } from "../../definitions/BoneDataType";
 import { ShaderVariableUpdateInterval } from "../../definitions/ShaderVariableUpdateInterval";
+import WebGLContextWrapper from "../../../webgl/WebGLContextWrapper";
 
 type MaterialTypeName = string;
 type ShaderVariable = {
@@ -464,17 +465,18 @@ export default class Material extends RnObject {
   private __setupGlobalShaderDefinition() {
     let definitions = '';
     const webglResourceRepository = CGAPIResourceRepository.getWebGLResourceRepository();
-    if (webglResourceRepository.currentWebGLContextWrapper?.isWebGL2) {
+    const glw = webglResourceRepository.currentWebGLContextWrapper as WebGLContextWrapper;
+    if (glw.isWebGL2) {
       definitions += '#version 300 es\n#define GLSL_ES3\n';
     }
     definitions += `#define RN_MATERIAL_TYPE_NAME ${this.__materialTypeName}\n`;
     if (System.getInstance().processApproach === ProcessApproach.FastestWebGL1) {
       definitions += '#define RN_IS_FASTEST_MODE\n';
     }
-    if (webglResourceRepository.currentWebGLContextWrapper?.webgl1ExtSTL) {
+    if (glw.webgl1ExtSTL) {
       definitions += '#define WEBGL1_EXT_SHADER_TEXTURE_LOD\n';
     }
-    if (webglResourceRepository.currentWebGLContextWrapper?.webgl1ExtDRV) {
+    if (glw.webgl1ExtDRV) {
       definitions += '#define WEBGL1_EXT_STANDARD_DERIVATIVES\n';
     }
     if (Config.boneDataType === BoneDataType.Mat4x4) {

--- a/src/foundation/materials/singles/MToonSingleMaterialNode.ts
+++ b/src/foundation/materials/singles/MToonSingleMaterialNode.ts
@@ -64,11 +64,13 @@ export default class MToonSingleMaterialNode extends AbstractMaterialNode {
   private __vectorProperties: any = {};
   private __textureProperties: any = {};
 
-  constructor(isOutline: boolean, materialProperties: any, textures: any, isMorphing: boolean, isSkinning: boolean, isLighting: boolean, debugMode: Count | undefined) {
+  constructor(isOutline: boolean, materialProperties: any, textures: any, isMorphing: boolean, isSkinning: boolean, isLighting: boolean,
+    useTangentAttribute: boolean, debugMode: Count | undefined) {
     super(MToonShader.getInstance(), 'MToonShading'
       + (isMorphing ? '+morphing' : '')
       + (isSkinning ? '+skinning' : '')
-      + (isLighting ? '' : '-lighting'),
+      + (isLighting ? '' : '-lighting')
+      + (useTangentAttribute ? '+tangentAttribute' : ''),
       { isMorphing: isMorphing, isSkinning: isSkinning, isLighting: isLighting }
     );
 
@@ -334,6 +336,10 @@ export default class MToonSingleMaterialNode extends AbstractMaterialNode {
           initialValue: new VectorN(new Float32Array(Config.maxVertexMorphNumberInShader)), min: -Number.MAX_VALUE, max: Number.MAX_VALUE, needUniformInFastest: true
         }
       );
+    }
+
+    if (useTangentAttribute) {
+      this.__definitions += '#define RN_USE_TANGENT_ATTRIBUTE\n';
     }
 
     // Texture

--- a/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
+++ b/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
@@ -38,11 +38,12 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
   static readonly OcclusionTexcoordIndex = new ShaderSemanticsClass({ str: 'occlusionTexcoordIndex' });
   static readonly EmissiveTexcoordIndex = new ShaderSemanticsClass({ str: 'emissiveTexcoordIndex' });
 
-  constructor({ isMorphing, isSkinning, isLighting, alphaMode }: { isMorphing: boolean, isSkinning: boolean, isLighting: boolean, alphaMode: AlphaModeEnum }) {
+  constructor({ isMorphing, isSkinning, isLighting, useTangentAttribute, alphaMode }: { isMorphing: boolean, isSkinning: boolean, isLighting: boolean, useTangentAttribute: boolean, alphaMode: AlphaModeEnum }) {
     super(null, 'pbrShading'
       + (isMorphing ? '+morphing' : '')
       + (isSkinning ? '+skinning' : '')
       + (isLighting ? '' : '-lighting')
+      + (useTangentAttribute ? '+tangentAttribute' : '')
       + ' alpha_' + alphaMode.str.toLowerCase(),
       { isMorphing, isSkinning, isLighting }, pbrSingleShaderVertex, pbrSingleShaderFragment
     );
@@ -189,6 +190,10 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
           initialValue: new VectorN(new Float32Array(Config.maxVertexMorphNumberInShader)), min: -Number.MAX_VALUE, max: Number.MAX_VALUE, needUniformInFastest: true
         }
       );
+    }
+
+    if (useTangentAttribute) {
+      this.__definitions += '#define RN_USE_TANGENT_ATTRIBUTE\n';
     }
 
     this.__definitions += '#define RN_IS_ALPHAMODE_' + alphaMode.str + '\n';

--- a/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
+++ b/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
@@ -68,7 +68,7 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
         },
         {
           semantic: ShaderSemantics.NormalTexture, compositionType: CompositionType.Texture2D, componentType: ComponentType.Int,
-          stage: ShaderType.PixelShader, min: 0, max: Number.MAX_SAFE_INTEGER, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: [2, AbstractMaterialNode.__dummyBlueTexture]
+          stage: ShaderType.PixelShader, min: 0, max: Number.MAX_SAFE_INTEGER, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: [2, AbstractMaterialNode.__dummyBlackTexture]
         },
         {
           semantic: ShaderSemantics.OcclusionTexture, compositionType: CompositionType.Texture2D, componentType: ComponentType.Int,

--- a/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
+++ b/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
@@ -38,7 +38,7 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
   static readonly OcclusionTexcoordIndex = new ShaderSemanticsClass({ str: 'occlusionTexcoordIndex' });
   static readonly EmissiveTexcoordIndex = new ShaderSemanticsClass({ str: 'emissiveTexcoordIndex' });
 
-  constructor({ isMorphing, isSkinning, isLighting, useTangentAttribute, alphaMode }: { isMorphing: boolean, isSkinning: boolean, isLighting: boolean, useTangentAttribute: boolean, alphaMode: AlphaModeEnum }) {
+  constructor({ isMorphing, isSkinning, isLighting, useTangentAttribute, useNormalTexture, alphaMode }: { isMorphing: boolean, isSkinning: boolean, isLighting: boolean, useTangentAttribute: boolean, useNormalTexture: boolean, alphaMode: AlphaModeEnum }) {
     super(null, 'pbrShading'
       + (isMorphing ? '+morphing' : '')
       + (isSkinning ? '+skinning' : '')
@@ -65,10 +65,6 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
         {
           semantic: ShaderSemantics.MetallicRoughnessTexture, compositionType: CompositionType.Texture2D, componentType: ComponentType.Int,
           stage: ShaderType.PixelShader, min: 0, max: Number.MAX_SAFE_INTEGER, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: [1, AbstractMaterialNode.__dummyWhiteTexture]
-        },
-        {
-          semantic: ShaderSemantics.NormalTexture, compositionType: CompositionType.Texture2D, componentType: ComponentType.Int,
-          stage: ShaderType.PixelShader, min: 0, max: Number.MAX_SAFE_INTEGER, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: [2, AbstractMaterialNode.__dummyBlackTexture]
         },
         {
           semantic: ShaderSemantics.OcclusionTexture, compositionType: CompositionType.Texture2D, componentType: ComponentType.Int,
@@ -111,14 +107,6 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
           stage: ShaderType.PixelShader, min: -Math.PI, max: Math.PI, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
         },
         {
-          semantic: PbrShadingSingleMaterialNode.NormalTextureTransform, compositionType: CompositionType.Vec4, componentType: ComponentType.Float,
-          stage: ShaderType.PixelShader, min: -10, max: 10, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Vector4(1, 1, 0, 0)
-        },
-        {
-          semantic: PbrShadingSingleMaterialNode.NormalTextureRotation, compositionType: CompositionType.Scalar, componentType: ComponentType.Float,
-          stage: ShaderType.PixelShader, min: -Math.PI, max: Math.PI, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
-        },
-        {
           semantic: PbrShadingSingleMaterialNode.MetallicRoughnessTextureTransform, compositionType: CompositionType.Vec4, componentType: ComponentType.Float,
           stage: ShaderType.PixelShader, min: -10, max: 10, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Vector4(1, 1, 0, 0)
         },
@@ -127,10 +115,6 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
           stage: ShaderType.PixelShader, min: -Math.PI, max: Math.PI, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
         },
 
-        {
-          semantic: PbrShadingSingleMaterialNode.NormalTexcoordIndex, compositionType: CompositionType.Scalar, componentType: ComponentType.Int,
-          stage: ShaderType.PixelShader, min: 0, max: 1, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
-        },
         {
           semantic: PbrShadingSingleMaterialNode.BaseColorTexcoordIndex, compositionType: CompositionType.Scalar, componentType: ComponentType.Int,
           stage: ShaderType.PixelShader, min: 0, max: 1, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
@@ -194,6 +178,29 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
 
     if (useTangentAttribute) {
       this.__definitions += '#define RN_USE_TANGENT_ATTRIBUTE\n';
+    }
+
+    if (useNormalTexture) {
+      this.__definitions += '#define RN_USE_NORMAL_TEXTURE\n';
+
+      shaderSemanticsInfoArray.push(
+        {
+          semantic: ShaderSemantics.NormalTexture, compositionType: CompositionType.Texture2D, componentType: ComponentType.Int,
+          stage: ShaderType.PixelShader, min: 0, max: Number.MAX_SAFE_INTEGER, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: [2, AbstractMaterialNode.__dummyBlackTexture]
+        },
+        {
+          semantic: PbrShadingSingleMaterialNode.NormalTextureTransform, compositionType: CompositionType.Vec4, componentType: ComponentType.Float,
+          stage: ShaderType.PixelShader, min: -10, max: 10, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Vector4(1, 1, 0, 0)
+        },
+        {
+          semantic: PbrShadingSingleMaterialNode.NormalTextureRotation, compositionType: CompositionType.Scalar, componentType: ComponentType.Float,
+          stage: ShaderType.PixelShader, min: -Math.PI, max: Math.PI, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
+        },
+        {
+          semantic: PbrShadingSingleMaterialNode.NormalTexcoordIndex, compositionType: CompositionType.Scalar, componentType: ComponentType.Int,
+          stage: ShaderType.PixelShader, min: 0, max: 1, isSystem: false, updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly, initialValue: new Scalar(0)
+        }
+      );
     }
 
     this.__definitions += '#define RN_IS_ALPHAMODE_' + alphaMode.str + '\n';

--- a/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
+++ b/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
@@ -90,6 +90,7 @@ vec2 getTexcoord(int texcoordIndex) {
   return texcoord;
 }
 
+#pragma shaderity: require(../common/perturbedNormal.glsl)
 
 void main ()
 {

--- a/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
+++ b/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
@@ -8,12 +8,15 @@
 
 in vec3 v_color;
 in vec3 v_normal_inWorld;
-in vec3 v_tangent_inWorld;
-in vec3 v_binormal_inWorld;
 in vec4 v_position_inWorld;
 in vec2 v_texcoord_0;
 in vec2 v_texcoord_1;
 in vec3 v_baryCentricCoord;
+
+#ifdef RN_USE_TANGENT_ATTRIBUTE
+  in vec3 v_tangent_inWorld;
+  in vec3 v_binormal_inWorld;
+#endif
 
 #pragma shaderity: require(../common/rt0.glsl)
 
@@ -97,6 +100,11 @@ void main ()
 
 #pragma shaderity: require(../common/mainPrerequisites.glsl)
 
+  // View vector
+  float cameraSID = u_currentComponentSIDs[/* shaderity: @{WellKnownComponentTIDs.CameraComponentTID} */];
+  vec3 viewPosition = get_viewPosition(cameraSID, 0);
+  vec3 viewVector = viewPosition - v_position_inWorld.xyz;
+
   // Normal
   vec3 normal_inWorld = normalize(v_normal_inWorld);
   vec4 iblParameter = get_iblParameter(materialSID, 0);
@@ -104,28 +112,17 @@ void main ()
   mat3 rotEnvMatrix = mat3(cos(rot), 0.0, -sin(rot), 0.0, 1.0, 0.0, sin(rot), 0.0, cos(rot));
   vec3 normal_forEnv = rotEnvMatrix * normal_inWorld;
 
-  if (abs(length(v_tangent_inWorld)) > 0.01) {
-    vec4 normalTextureTransform = get_normalTextureTransform(materialSID, 0);
-    float normalTextureRotation = get_normalTextureRotation(materialSID, 0);
-    int normalTexcoordIndex = get_normalTexcoordIndex(materialSID, 0);
-    vec2 normalTexcoord = getTexcoord(normalTexcoordIndex);
-    vec2 normalTexUv = uvTransform(normalTextureTransform.xy, normalTextureTransform.zw, normalTextureRotation, normalTexcoord);
-    vec3 normal = texture2D(u_normalTexture, normalTexUv).xyz*2.0 - 1.0;
-    vec3 tangent_inWorld = normalize(v_tangent_inWorld);
-    vec3 binormal_inWorld = normalize(v_binormal_inWorld);
-    normal_inWorld = normalize(normal_inWorld);
-
-    mat3 tbnMat_tangent_to_world = mat3(
-      tangent_inWorld.x, tangent_inWorld.y, tangent_inWorld.z,
-      binormal_inWorld.x, binormal_inWorld.y, binormal_inWorld.z,
-      normal_inWorld.x, normal_inWorld.y, normal_inWorld.z
-    );
-
-    normal = normalize(tbnMat_tangent_to_world * normal);
-    normal_inWorld = normal;
+  vec4 normalTextureTransform = get_normalTextureTransform(materialSID, 0);
+  float normalTextureRotation = get_normalTextureRotation(materialSID, 0);
+  int normalTexcoordIndex = get_normalTexcoordIndex(materialSID, 0);
+  vec2 normalTexcoord = getTexcoord(normalTexcoordIndex);
+  vec2 normalTexUv = uvTransform(normalTextureTransform.xy, normalTextureTransform.zw, normalTextureRotation, normalTexcoord);
+  vec3 normalTexValue = texture2D(u_normalTexture, normalTexUv).xyz;
+  if(normalTexValue.b >= 128.0 / 255.0) {
+    // normal texture is existence
+    vec3 normalTex = normalTexValue * 2.0 - 1.0;
+    normal_inWorld = perturb_normal(normal_inWorld, viewVector, normalTexUv, normalTex);
   }
-
-
 
   // BaseColorFactor
   vec3 baseColor = vec3(0.0, 0.0, 0.0);
@@ -184,10 +181,8 @@ void main ()
   vec3 albedo = baseColor.rgb * (vec3(1.0) - diffuseMatAverageF0);
   albedo.rgb *= (1.0 - metallic);
 
-  // ViewDirection
-  float cameraSID = u_currentComponentSIDs[/* shaderity: @{WellKnownComponentTIDs.CameraComponentTID} */];
-  vec3 viewPosition = get_viewPosition(cameraSID, 0);
-  vec3 viewDirection = normalize(viewPosition - v_position_inWorld.xyz);
+  // View direction
+  vec3 viewDirection = normalize(viewVector);
 
   // NV
   float NV = clamp(abs(dot(normal_inWorld, viewDirection)), 0.0, 1.0);

--- a/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
+++ b/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.frag
@@ -112,17 +112,19 @@ void main ()
   mat3 rotEnvMatrix = mat3(cos(rot), 0.0, -sin(rot), 0.0, 1.0, 0.0, sin(rot), 0.0, cos(rot));
   vec3 normal_forEnv = rotEnvMatrix * normal_inWorld;
 
-  vec4 normalTextureTransform = get_normalTextureTransform(materialSID, 0);
-  float normalTextureRotation = get_normalTextureRotation(materialSID, 0);
-  int normalTexcoordIndex = get_normalTexcoordIndex(materialSID, 0);
-  vec2 normalTexcoord = getTexcoord(normalTexcoordIndex);
-  vec2 normalTexUv = uvTransform(normalTextureTransform.xy, normalTextureTransform.zw, normalTextureRotation, normalTexcoord);
-  vec3 normalTexValue = texture2D(u_normalTexture, normalTexUv).xyz;
-  if(normalTexValue.b >= 128.0 / 255.0) {
-    // normal texture is existence
-    vec3 normalTex = normalTexValue * 2.0 - 1.0;
-    normal_inWorld = perturb_normal(normal_inWorld, viewVector, normalTexUv, normalTex);
-  }
+  #ifdef RN_USE_NORMAL_TEXTURE
+    vec4 normalTextureTransform = get_normalTextureTransform(materialSID, 0);
+    float normalTextureRotation = get_normalTextureRotation(materialSID, 0);
+    int normalTexcoordIndex = get_normalTexcoordIndex(materialSID, 0);
+    vec2 normalTexcoord = getTexcoord(normalTexcoordIndex);
+    vec2 normalTexUv = uvTransform(normalTextureTransform.xy, normalTextureTransform.zw, normalTextureRotation, normalTexcoord);
+    vec3 normalTexValue = texture2D(u_normalTexture, normalTexUv).xyz;
+    if(normalTexValue.b >= 128.0 / 255.0) {
+      // normal texture is existence
+      vec3 normalTex = normalTexValue * 2.0 - 1.0;
+      normal_inWorld = perturb_normal(normal_inWorld, viewVector, normalTexUv, normalTex);
+    }
+  #endif
 
   // BaseColorFactor
   vec3 baseColor = vec3(0.0, 0.0, 0.0);

--- a/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.vert
+++ b/src/webgl/shaderity_shaders/PbrSingleShader/PbrSingleShader.vert
@@ -6,7 +6,6 @@
 in vec3 a_position;
 in vec3 a_color;
 in vec3 a_normal;
-in vec4 a_tangent;
 in float a_instanceID;
 in vec2 a_texcoord_0;
 in vec2 a_texcoord_1;
@@ -15,12 +14,15 @@ in vec4 a_weight;
 in vec4 a_baryCentricCoord;
 out vec3 v_color;
 out vec3 v_normal_inWorld;
-out vec3 v_tangent_inWorld;
-out vec3 v_binormal_inWorld;
 out vec4 v_position_inWorld;
 out vec2 v_texcoord_0;
 out vec2 v_texcoord_1;
 out vec3 v_baryCentricCoord;
+#ifdef RN_USE_TANGENT_ATTRIBUTE
+  in vec4 a_tangent;
+  out vec3 v_tangent_inWorld;
+  out vec3 v_binormal_inWorld;
+#endif
 
 #pragma shaderity: require(../common/prerequisites.glsl)
 
@@ -65,13 +67,13 @@ void main()
   v_texcoord_0 = a_texcoord_0;
   v_texcoord_1 = a_texcoord_1;
 
-  if (abs(length(a_normal)) > 0.01) {
-    // if normal exist
+
+  #ifdef RN_USE_TANGENT_ATTRIBUTE
     vec3 tangent_inWorld = normalMatrix * a_tangent.xyz;
 
     v_binormal_inWorld = cross(v_normal_inWorld, tangent_inWorld) * a_tangent.w;
     v_tangent_inWorld = cross(v_binormal_inWorld, v_normal_inWorld);
-  }
+  #endif
   v_baryCentricCoord = a_baryCentricCoord.xyz;
 
 #pragma shaderity: require(../common/pointSprite.glsl)

--- a/src/webgl/shaderity_shaders/common/perturbedNormal.glsl
+++ b/src/webgl/shaderity_shaders/common/perturbedNormal.glsl
@@ -1,0 +1,44 @@
+#ifdef RN_USE_TANGENT_ATTRIBUTE
+  vec3 perturb_normal(vec3 normal_inWorld, vec3 viewVector, vec2 texcoord) {
+    vec3 tangent_inWorld = normalize(v_tangent_inWorld);
+    vec3 binormal_inWorld = normalize(v_binormal_inWorld);
+    mat3 tbnMat_tangent_to_world = mat3(tangent_inWorld, binormal_inWorld, normal_inWorld);
+
+    vec3 normal = texture2D(u_normalTexture, texcoord).xyz * 2.0 - 1.0;
+    return normalize(tbnMat_tangent_to_world * normal);
+  }
+#else
+  #ifdef RN_IS_SUPPORTING_STANDARD_DERIVATIVES
+    // This is based on http://www.thetenthplanet.de/archives/1180
+    mat3 cotangent_frame(vec3 normal, vec3 position, vec2 uv) {
+      uv = gl_FrontFacing ? uv : -uv;
+
+      // get edge vectors of the pixel triangle
+      vec3 dp1 = dFdx(position);
+      vec3 dp2 = dFdy(position);
+      vec2 duv1 = dFdx(uv);
+      vec2 duv2 = dFdy(uv);
+
+      // solve the linear system
+      vec3 dp2perp = cross(dp2, normal);
+      vec3 dp1perp = cross(normal, dp1);
+      vec3 tangent = dp2perp * duv1.x + dp1perp * duv2.x;
+      vec3 bitangent = dp2perp * duv1.y + dp1perp * duv2.y;
+
+      // construct a scale-invariant frame
+      float invMat = inversesqrt(max(dot(tangent, tangent), dot(bitangent, bitangent)));
+      return mat3(tangent * invMat, bitangent * invMat, normal);
+    }
+
+    vec3 perturb_normal(vec3 normal, vec3 viewVector, vec2 texcoord) {
+      vec3 normalTex = texture2D(u_normalTexture, texcoord).xyz * 2.0 - 1.0;
+
+      mat3 tbnMat_tangent_to_world = cotangent_frame(normal, -viewVector, texcoord);
+      return normalize(tbnMat_tangent_to_world * normalTex);
+    }
+  #else
+    vec3 perturb_normal(vec3 normal, vec3 viewVector, vec2 texcoord) {
+      return normal;
+    }
+  #endif
+#endif

--- a/src/webgl/shaderity_shaders/common/perturbedNormal.glsl
+++ b/src/webgl/shaderity_shaders/common/perturbedNormal.glsl
@@ -1,16 +1,15 @@
 #ifdef RN_USE_TANGENT_ATTRIBUTE
-  vec3 perturb_normal(vec3 normal_inWorld, vec3 viewVector, vec2 texcoord) {
+  vec3 perturb_normal(vec3 normal_inWorld, vec3 viewVector, vec2 texcoord, vec3 normalTex) {
     vec3 tangent_inWorld = normalize(v_tangent_inWorld);
     vec3 binormal_inWorld = normalize(v_binormal_inWorld);
     mat3 tbnMat_tangent_to_world = mat3(tangent_inWorld, binormal_inWorld, normal_inWorld);
 
-    vec3 normal = texture2D(u_normalTexture, texcoord).xyz * 2.0 - 1.0;
-    return normalize(tbnMat_tangent_to_world * normal);
+    return normalize(tbnMat_tangent_to_world * normalTex);
   }
 #else
   #ifdef RN_IS_SUPPORTING_STANDARD_DERIVATIVES
     // This is based on http://www.thetenthplanet.de/archives/1180
-    mat3 cotangent_frame(vec3 normal, vec3 position, vec2 uv) {
+    mat3 cotangent_frame(vec3 normal_inWorld, vec3 position, vec2 uv) {
       uv = gl_FrontFacing ? uv : -uv;
 
       // get edge vectors of the pixel triangle
@@ -20,25 +19,23 @@
       vec2 duv2 = dFdy(uv);
 
       // solve the linear system
-      vec3 dp2perp = cross(dp2, normal);
-      vec3 dp1perp = cross(normal, dp1);
+      vec3 dp2perp = cross(dp2, normal_inWorld);
+      vec3 dp1perp = cross(normal_inWorld, dp1);
       vec3 tangent = dp2perp * duv1.x + dp1perp * duv2.x;
       vec3 bitangent = dp2perp * duv1.y + dp1perp * duv2.y;
 
       // construct a scale-invariant frame
       float invMat = inversesqrt(max(dot(tangent, tangent), dot(bitangent, bitangent)));
-      return mat3(tangent * invMat, bitangent * invMat, normal);
+      return mat3(tangent * invMat, bitangent * invMat, normal_inWorld);
     }
 
-    vec3 perturb_normal(vec3 normal, vec3 viewVector, vec2 texcoord) {
-      vec3 normalTex = texture2D(u_normalTexture, texcoord).xyz * 2.0 - 1.0;
-
-      mat3 tbnMat_tangent_to_world = cotangent_frame(normal, -viewVector, texcoord);
+    vec3 perturb_normal(vec3 normal_inWorld, vec3 viewVector, vec2 texcoord, vec3 normalTex) {
+      mat3 tbnMat_tangent_to_world = cotangent_frame(normal_inWorld, -viewVector, texcoord);
       return normalize(tbnMat_tangent_to_world * normalTex);
     }
   #else
-    vec3 perturb_normal(vec3 normal, vec3 viewVector, vec2 texcoord) {
-      return normal;
+    vec3 perturb_normal(vec3 normal_inWorld, vec3 viewVector, vec2 texcoord, vec3 normalTex) {
+      return normal_inWorld;
     }
   #endif
 #endif

--- a/src/webgl/shaders/GLSLShader.ts
+++ b/src/webgl/shaders/GLSLShader.ts
@@ -652,6 +652,55 @@ vec3 descramble(vec3 v) {
     `
   }
 
+  get perturbedNormal() {
+    return `
+#ifdef RN_USE_TANGENT_ATTRIBUTE
+  vec3 perturb_normal(vec3 normal_inWorld, vec3 viewVector, vec2 texcoord) {
+    vec3 tangent_inWorld = normalize(v_tangent_inWorld);
+    vec3 binormal_inWorld = normalize(v_binormal_inWorld);
+    mat3 tbnMat_tangent_to_world = mat3(tangent_inWorld, binormal_inWorld, normal_inWorld);
+
+    vec3 normal = texture2D(u_normalTexture, texcoord).xyz * 2.0 - 1.0;
+    return normalize(tbnMat_tangent_to_world * normal);
+  }
+#else
+  #ifdef RN_IS_SUPPORTING_STANDARD_DERIVATIVES
+    // This is based on http://www.thetenthplanet.de/archives/1180
+    mat3 cotangent_frame(vec3 normal, vec3 position, vec2 uv) {
+      uv = gl_FrontFacing ? uv : -uv;
+
+      // get edge vectors of the pixel triangle
+      vec3 dp1 = dFdx(position);
+      vec3 dp2 = dFdy(position);
+      vec2 duv1 = dFdx(uv);
+      vec2 duv2 = dFdy(uv);
+
+      // solve the linear system
+      vec3 dp2perp = cross(dp2, normal);
+      vec3 dp1perp = cross(normal, dp1);
+      vec3 tangent = dp2perp * duv1.x + dp1perp * duv2.x;
+      vec3 bitangent = dp2perp * duv1.y + dp1perp * duv2.y;
+
+      // construct a scale-invariant frame
+      float invMat = inversesqrt(max(dot(tangent, tangent), dot(bitangent, bitangent)));
+      return mat3(tangent * invMat, bitangent * invMat, normal);
+    }
+
+    vec3 perturb_normal(vec3 normal, vec3 viewVector, vec2 texcoord) {
+      vec3 normalTex = texture2D(u_normalTexture, texcoord).xyz * 2.0 - 1.0;
+
+      mat3 tbnMat_tangent_to_world = cotangent_frame(normal, -viewVector, texcoord);
+      return normalize(tbnMat_tangent_to_world * normalTex);
+    }
+  #else
+    vec3 perturb_normal(vec3 normal, vec3 viewVector, vec2 texcoord) {
+      return normal;
+    }
+  #endif
+#endif
+`;
+  }
+
   static getStringFromShaderAnyDataType(data: ShaderAttributeOrSemanticsOrString): string {
     if (data instanceof ShaderSemanticsClass) {
       return 'u_' + data.str;

--- a/src/webgl/shaders/MToonShader.ts
+++ b/src/webgl/shaders/MToonShader.ts
@@ -197,6 +197,8 @@ vec3 srgbToLinear(vec3 srgbColor) {
   return pow(srgbColor, vec3(2.2));
 }
 
+${this.perturbedNormal}
+
 void main (){
   #ifdef RN_MTOON_IS_OUTLINE
     #ifdef RN_MTOON_OUTLINE_NONE

--- a/src/webgl/shaders/MToonShader.ts
+++ b/src/webgl/shaders/MToonShader.ts
@@ -40,18 +40,21 @@ ${_in} float a_instanceID;
 ${_in} vec2 a_texcoord_0;
 ${_in} vec3 a_position;
 ${_in} vec3 a_normal;
-${_in} vec3 a_tangent;
 ${_in} vec4 a_baryCentricCoord;
 ${_in} vec4 a_joint;
 ${_in} vec4 a_weight;
 
 ${_out} vec2 v_texcoord_0;
 ${_out} vec3 v_baryCentricCoord;
-${_out} vec3 v_binormal_inWorld; // bitangent_inWorld
 ${_out} vec3 v_normal_inView;
 ${_out} vec3 v_normal_inWorld;
-${_out} vec3 v_tangent_inWorld;
 ${_out} vec4 v_position_inWorld;
+
+#ifdef RN_USE_TANGENT_ATTRIBUTE
+${_in} vec4 a_tangent;
+${_out} vec3 v_tangent_inWorld;
+${_out} vec3 v_binormal_inWorld; // bitangent_inWorld
+#endif
 
 ${this.prerequisites}
 
@@ -127,20 +130,14 @@ void main(){
     #endif
   #endif
 
-  if (abs(length(a_normal)) > 0.01) {
-    // if normal exist
-    vec3 tangent_inWorld;
-    if (!isSkinning) {
-      tangent_inWorld = normalMatrix * a_tangent;
-      v_position_inWorld = worldMatrix * vec4(a_position, 1.0);
-    }
+  #ifdef RN_USE_TANGENT_ATTRIBUTE
+    vec3 tangent_inWorld = normalMatrix * a_tangent.xyz;
 
-    v_binormal_inWorld = cross(v_normal_inWorld, tangent_inWorld);
+    v_binormal_inWorld = cross(v_normal_inWorld, tangent_inWorld) * a_tangent.w;
     v_tangent_inWorld = cross(v_binormal_inWorld, v_normal_inWorld);
-  }
+  #endif
 
   v_texcoord_0 = a_texcoord_0;
-
   v_baryCentricCoord = a_baryCentricCoord.xyz;
 }`
   }
@@ -175,11 +172,14 @@ const float EPS_COL = 0.00001;
 
 ${_in} vec2 v_texcoord_0;
 ${_in} vec3 v_baryCentricCoord;
-${_in} vec3 v_binormal_inWorld; // bitangent_inWorld
 ${_in} vec3 v_normal_inView;
 ${_in} vec3 v_normal_inWorld;
-${_in} vec3 v_tangent_inWorld;
 ${_in} vec4 v_position_inWorld;
+#ifdef RN_USE_TANGENT_ATTRIBUTE
+  ${_in} vec3 v_tangent_inWorld;
+  ${_in} vec3 v_binormal_inWorld; // bitangent_inWorld
+#endif
+
 ${_def_rt0}
 
 ${(typeof args.getters !== 'undefined') ? args.getters : ''}
@@ -247,26 +247,15 @@ void main (){
     #endif
   #endif
 
+  // view vector
+  float cameraSID = u_currentComponentSIDs[${WellKnownComponentTIDs.CameraComponentTID}];
+  vec3 viewPosition = get_viewPosition(cameraSID, 0);
+  vec3 viewVector = viewPosition - v_position_inWorld.xyz;
 
   // Normal
   vec3 normal_inWorld = normalize(v_normal_inWorld);
-
   #ifdef RN_MTOON_HAS_BUMPMAP
-    if (abs(length(v_tangent_inWorld)) > 0.01) {
-      vec3 tangent_inWorld = normalize(v_tangent_inWorld);
-      vec3 binormal_inWorld = normalize(v_binormal_inWorld);
-
-      mat3 tbnMat_tangent_to_world = mat3(
-        tangent_inWorld.x, tangent_inWorld.y, tangent_inWorld.z,
-        binormal_inWorld.x, binormal_inWorld.y, binormal_inWorld.z,
-        normal_inWorld.x, normal_inWorld.y, normal_inWorld.z
-      );
-
-      vec3 normal = ${_texture}(u_normalTexture, v_texcoord_0).xyz * 2.0 - 1.0;
-      float normalScale = get_normalScale(materialSID, 0);
-      normal.xy *= normalScale;
-      normal_inWorld = normalize(tbnMat_tangent_to_world * normal);
-    }
+    normal_inWorld = perturb_normal(normal_inWorld, viewVector, v_texcoord_0);
   #endif
 
   #ifdef RN_MTOON_IS_OUTLINE
@@ -394,9 +383,7 @@ void main (){
       rt0.xyz = outlineColor * mix(vec3(1.0), rt0.xyz, outlineLightingMix);
     #endif
   #else
-    float cameraSID = u_currentComponentSIDs[${WellKnownComponentTIDs.CameraComponentTID}];
-    vec3 viewPosition = get_viewPosition(cameraSID, 0);
-    vec3 viewDirection = normalize(viewPosition - v_position_inWorld.xyz);
+    vec3 viewDirection = normalize(viewVector);
 
     float rimFresnelPower = get_rimFresnelPower(materialSID, 0);
     float rimLift = get_rimLift(materialSID, 0);


### PR DESCRIPTION
This PR improves the speed of loading when the gltf2.0 model does not have a tangent attribute. Furthermore, this PR fixes #612 in a normal 1.0 case.

I implemented a tangent calculation in a shader with reference to http://www.thetenthplanet.de/archives/1180. This implementation computes the tangent in the shader in real-time. We do not need to precompute the tangent anymore, thus reducing the load time.

For this implementation, I changed the tangent calculation mode as follows
0: Do not correct for normal using a normal map (do not set the normal map).
1: If there is a tangent in the gltf, use its value, otherwise the shader will calculate it (default).
2: If there is a tangent in the gltf, use its value, otherwise, pre-calculate it in javascript (typescript) as before.
3: Ignore the tangent in the gltf and calculate all of them in the shader.
4: Ignore the tangent in the gltf and pre-calculate all of them.

