### PR TITLE
Reuse materials, if those are duplicated

### DIFF
--- a/src/commontypes/glTF.ts
+++ b/src/commontypes/glTF.ts
@@ -296,7 +296,7 @@ export type glTF2 = {
     extras?: {
       rnLoaderOptions?: GltfLoadOption,
       rnEntities?: Entity[],
-      rnMaterials?: Material[],
+      rnMaterials?: { [s: string]: Material; },
       basePath?: string,
       version?: string,
       fileType?: string,

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -775,11 +775,12 @@ export default class ModelConverter {
       return (node.skin != null) ? true : false;
     }
   }
+
   private __getMaterialHash(node: Gltf2Node, gltfModel: glTF2, primitive: Gltf2Primitive, materialJson: any) {
-    return primitive.materialIndex! + "_" +
-      this.__isSkinning(node, gltfModel) + "_" +
-      this.__isMorphing(node, gltfModel) + "_" +
-      this.__isLighting(gltfModel, materialJson);
+    return primitive.materialIndex! +
+      "_isSkinning_" + this.__isSkinning(node, gltfModel) +
+      "_isMorphing_" + this.__isMorphing(node, gltfModel) +
+      "_isLighting_" + this.__isLighting(gltfModel, materialJson);
   }
 
   private __setupMaterial(rnPrimitive: Primitive, node: any, gltfModel: glTF2, primitive: Gltf2Primitive, materialJson: any): Material {

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -776,11 +776,10 @@ export default class ModelConverter {
     }
   }
   private __getMaterialHash(node: Gltf2Node, gltfModel: glTF2, primitive: Gltf2Primitive, materialJson: any) {
-    const argument = gltfModel?.asset?.extras?.rnLoaderOptions?.defaultMaterialHelperArgumentArray[0];
     return primitive.materialIndex! + "_" +
-      argument?.isSkinning + "_" + this.__isSkinning(node, gltfModel) + "_" +
-      argument?.isMorphing + "_" + this.__isMorphing(node, gltfModel) + "_" +
-      argument?.isLighting + "_" + this.__isLighting(gltfModel, materialJson);
+      this.__isSkinning(node, gltfModel) + "_" +
+      this.__isMorphing(node, gltfModel) + "_" +
+      this.__isLighting(gltfModel, materialJson);
   }
 
   private __setupMaterial(rnPrimitive: Primitive, node: any, gltfModel: glTF2, primitive: Gltf2Primitive, materialJson: any): Material {

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -118,7 +118,7 @@ export default class ModelConverter {
     (gltfModel.asset.extras as any).rnMeshesAtGltMeshIdx = [];
 
     const rnBuffers = this.createRnBuffer(gltfModel);
-    gltfModel.asset.extras!.rnMaterials = [];
+    gltfModel.asset.extras!.rnMaterials = {};
 
     // Mesh, Camera, Group, ...
     const { rnEntities, rnEntitiesByNames } = this.__setupObjects(gltfModel, rnBuffers);
@@ -775,14 +775,22 @@ export default class ModelConverter {
       return (node.skin != null) ? true : false;
     }
   }
+  private __getMaterialHash(node: Gltf2Node, gltfModel: glTF2, primitive: Gltf2Primitive, materialJson: any) {
+    const argument = gltfModel?.asset?.extras?.rnLoaderOptions?.defaultMaterialHelperArgumentArray[0];
+    return primitive.materialIndex! + "_" +
+      argument?.isSkinning + "_" + this.__isSkinning(node, gltfModel) + "_" +
+      argument?.isMorphing + "_" + this.__isMorphing(node, gltfModel) + "_" +
+      argument?.isLighting + "_" + this.__isLighting(gltfModel, materialJson);
+  }
 
   private __setupMaterial(rnPrimitive: Primitive, node: any, gltfModel: glTF2, primitive: Gltf2Primitive, materialJson: any): Material {
-    let material = gltfModel.asset.extras?.rnMaterials![primitive.materialIndex!];
-    if (material?.isSkinning === this.__isSkinning(node, gltfModel) && material.isMorphing === this.__isMorphing(node, gltfModel)) {
+    const materialHash = this.__getMaterialHash(node, gltfModel, primitive, materialJson);
+    let material = gltfModel.asset.extras?.rnMaterials![materialHash];
+    if (material != null) {
       return material;
     } else {
       const newMaterial: Material = this.__generateAppropriateMaterial(rnPrimitive, node, gltfModel, primitive, materialJson);
-      gltfModel.asset.extras!.rnMaterials![primitive.materialIndex!] = newMaterial;
+      gltfModel.asset.extras!.rnMaterials![materialHash] = newMaterial;
       material = newMaterial;
     }
 


### PR DESCRIPTION
# Description

It was found that when loading glTF, if there are multiple materials with the same material index and different attributes (skinning and morphing), the reuse of the materials does not occur as expected. To improve this, i attempted to change the keys indexed to reuse the material to include not only the material index but also other attributes.

This problem occurs because Rhodonite Materials with different attribute values are repeatedly assigned to the rnMaterials using the same material index as the key.
https://github.com/actnwit/RhodoniteTS/blob/8d7a9aa90df7a78e8f0c1934194699581565509c/src/foundation/importer/ModelConverter.ts#L785

## TODO

- [x] Implement to change the key of rnMaterials from the material index to a hash of the material's attribute value
- [x] Draw a test glTF to verify that the Material is actually reused
(call the Rn.Material.getAllMaterials() method before and after the change in Rhodonite and check the behavior by comparing the number of its elements. The glTF used for testing is the following)

[skin-cylinder.zip](https://github.com/actnwit/RhodoniteTS/files/5646726/skin-cylinder.zip)


