### PR TITLE
Avoid duplicate drawing

### DIFF
--- a/src/webgl/WebGLStrategyCommonMethod.ts
+++ b/src/webgl/WebGLStrategyCommonMethod.ts
@@ -5,6 +5,7 @@ import { AlphaMode } from "../foundation/definitions/AlphaMode";
 import MeshRendererComponent from "../foundation/components/MeshRendererComponent";
 import MeshComponent from "../foundation/components/MeshComponent";
 import CGAPIResourceRepository from "../foundation/renderer/CGAPIResourceRepository";
+import { Index } from "../commontypes/CommonTypes";
 
 let lastIsTransparentMode: boolean;
 let lastBlendEquationMode: number;
@@ -163,4 +164,18 @@ function isMaterialsSetup(meshComponent: MeshComponent) {
 
 }
 
-export default Object.freeze({ setCullAndBlendSettings, startDepthMasking, endDepthMasking, isMeshSetup, isMaterialsSetup });
+function isSkipDrawing(material: Material, idx: Index) {
+  if (
+    material.isEmptyMaterial() ||
+    material._shaderProgramUid === -1 ||
+    (idx < MeshRendererComponent.firstTransparentIndex && material.isBlend()) ||
+    (idx >= MeshRendererComponent.firstTransparentIndex && !material.isBlend())
+  ) {
+    return true;
+  } else {
+    return false
+  }
+
+}
+
+export default Object.freeze({ setCullAndBlendSettings, startDepthMasking, endDepthMasking, isMeshSetup, isMaterialsSetup, isSkipDrawing });

--- a/src/webgl/WebGLStrategyFastestWebGL1.ts
+++ b/src/webgl/WebGLStrategyFastestWebGL1.ts
@@ -630,8 +630,8 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
         if (meshComponent == null) {
           break;
         }
-        const mesh = meshComponent.mesh!;
-        if (!(mesh && mesh.isOriginalMesh())) {
+        const mesh = meshComponent.mesh;
+        if (!(mesh?.isOriginalMesh())) {
           continue;
         }
 

--- a/src/webgl/WebGLStrategyFastestWebGL1.ts
+++ b/src/webgl/WebGLStrategyFastestWebGL1.ts
@@ -647,18 +647,12 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
 
         for (let i = 0; i < primitiveNum; i++) {
           const primitive = mesh.getPrimitiveAt(i);
-
           const material: Material = renderPass.getAppropriateMaterial(primitive, primitive.material);
-          if (material.isEmptyMaterial()) {
+          if (WebGLStrategyCommonMethod.isSkipDrawing(material, idx)) {
             continue;
           }
 
           const shaderProgramUid = material._shaderProgramUid;
-          if (shaderProgramUid === -1) {
-            continue;
-          }
-
-
 
           this.attachVertexDataInner(mesh, primitive, i, glw, mesh.variationVBOUid);
           if (shaderProgramUid !== this.__lastShader) {

--- a/src/webgl/WebGLStrategyUniform.ts
+++ b/src/webgl/WebGLStrategyUniform.ts
@@ -342,7 +342,7 @@ mat3 get_normalMatrix(float instanceId) {
       this.attachVertexDataInner(meshComponent.mesh, primitive, i, glw, CGAPIResourceRepository.InvalidCGAPIResourceUid);
 
       const material: Material = renderPass.getAppropriateMaterial(primitive, primitive.material!);
-      if (material.isEmptyMaterial() || material._shaderProgramUid === -1) {
+      if (WebGLStrategyCommonMethod.isSkipDrawing(material, idx)) {
         continue;
       }
 


### PR DESCRIPTION
This PR fixes #667. I fixed the following problem.

[problem]
In the $render method, a model should be drawn in the following order:
(opaque primitives) -> (transparent primitives)

However, a model was drawn in the following order:
(opaque meshes and opaque and transparent meshes) -> (transparent meshes and opaque and transparent meshes)

That means if a mesh has both types of transparent and opaque primitive, the $render($common_render) method drew the mesh twice.