### PR TITLE
Support tests on mac mini

### DIFF
--- a/samples/test_e2e/GltfImporter-skinning-mat44/main.js
+++ b/samples/test_e2e/GltfImporter-skinning-mat44/main.js
@@ -3,6 +3,7 @@ document.body.appendChild(p);
 
 const load = async function () {
   Rn.Config.boneDataType = Rn.BoneDataType.Mat4x4;
+  Rn.Config.maxSkeletalBoneNumber = 2;
 
   await Rn.ModuleManager.getInstance().loadModule('webgl');
   await Rn.ModuleManager.getInstance().loadModule('pbr');

--- a/samples/test_e2e/GltfImporter-skinning-vec4-1/main.js
+++ b/samples/test_e2e/GltfImporter-skinning-vec4-1/main.js
@@ -3,6 +3,7 @@ document.body.appendChild(p);
 
 const load = async function () {
   Rn.Config.boneDataType = Rn.BoneDataType.Vec4x1;
+  Rn.Config.maxSkeletalBoneNumber = 2;
 
   await Rn.ModuleManager.getInstance().loadModule('webgl');
   await Rn.ModuleManager.getInstance().loadModule('pbr');

--- a/samples/test_e2e/GltfImporter-skinning-vec4-2/main.js
+++ b/samples/test_e2e/GltfImporter-skinning-vec4-2/main.js
@@ -3,6 +3,7 @@ document.body.appendChild(p);
 
 const load = async function () {
   Rn.Config.boneDataType = Rn.BoneDataType.Vec4x2;
+  Rn.Config.maxSkeletalBoneNumber = 2;
 
   await Rn.ModuleManager.getInstance().loadModule('webgl');
   await Rn.ModuleManager.getInstance().loadModule('pbr');

--- a/src/foundation/misc/RnPromise.test.ts
+++ b/src/foundation/misc/RnPromise.test.ts
@@ -77,7 +77,8 @@ test('Promise all callback', async () => {
     }
 
     RnPromise.allWithProgressCallback([p1, p2, p3], callback).then((results: any) => {
-      p1.then((resolve: any)=> {
+      expect(results).toEqual([1, 2, 3]);
+      p1.then(() => {
         resolve();
       })
     });


### PR DESCRIPTION
This PR fixes #669.

There are two errors. One is in the unit-test for the RnPromise. Another one is in the e2e-tests of the skinning.

A unit test for the RnPromise is failed because, 'resolve' variable in the following link is an object of the RnPromise, however the 'resolve' is used as function in the next line.
https://github.com/actnwit/RhodoniteTS/blob/38144eb92ddc7cd5b67614d14e99d08dcfb8d651/src/foundation/misc/RnPromise.test.ts#L80
I changed the usage of the 'resolve'.

The e2e-tests of skinning is failure because, there are the default setting of the rhodonite uses too many uniforms. The mac mini supports 1024 uniforms of vector in the vertex shader. However, the Rhodonite uses more than 1024 vectors by skinning. I decrease the number of uniforms by set parameter to Config.maxSkeletalBoneNumber.