### PR TITLE
Support generic purpose UBO access

### DIFF
--- a/src/foundation/core/Config.ts
+++ b/src/foundation/core/Config.ts
@@ -1,5 +1,6 @@
 import { BoneDataType } from "../definitions/BoneDataType";
 
+let byteAlignOfBuffer = 16;
 let maxEntityNumber = 5000;
 let maxLightNumberInShader = 4;
 let maxVertexMorphNumberInShader = 41;

--- a/src/foundation/materials/core/AbstractMaterialNode.ts
+++ b/src/foundation/materials/core/AbstractMaterialNode.ts
@@ -405,7 +405,9 @@ export default abstract class AbstractMaterialNode extends RnObject {
     const array: number[] = primitive.targets.map((target: Attributes) => {
       const accessor = target.get(VertexAttribute.Position) as Accessor;
       let offset = 0;
-      if (SystemState.currentProcessApproach === ProcessApproach.FastestWebGL1) {
+      if (SystemState.currentProcessApproach === ProcessApproach.FastestWebGL1 ||
+        SystemState.currentProcessApproach === ProcessApproach.FastestWebGL2
+        ) {
         offset = memoryManager.createOrGetBuffer(BufferUse.GPUInstanceData).takenSizeInByte;
       }
       return (offset + accessor.byteOffsetInBuffer) / 4 / 4;

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -511,8 +511,17 @@ export default class Material extends RnObject {
     let vertexShaderBody = '';
     let pixelShaderBody = '';
     if (materialNode.vertexShaderityObject != null) {
-      vertexShaderBody = ShaderityUtility.getInstance().getVertexShaderBody(materialNode.vertexShaderityObject, { getters: vertexPropertiesStr, definitions: definitions, matricesGetters: vertexShaderMethodDefinitions_uniform })
-      pixelShaderBody = ShaderityUtility.getInstance().getPixelShaderBody(materialNode.pixelShaderityObject!, { getters: pixelPropertiesStr, definitions: definitions });
+      vertexShaderBody = ShaderityUtility.getInstance().getVertexShaderBody(materialNode.vertexShaderityObject, { 
+          getters: vertexPropertiesStr,
+          definitions: definitions,
+          dataUBODefinition: webglResourceRepository.getGlslDataUBODefinitionString(),
+          matricesGetters: vertexShaderMethodDefinitions_uniform
+        })
+      pixelShaderBody = ShaderityUtility.getInstance().getPixelShaderBody(materialNode.pixelShaderityObject!, {
+        getters: pixelPropertiesStr,
+        definitions: definitions,
+        dataUBODefinition: webglResourceRepository.getGlslDataUBODefinitionString()
+      });
     } else {
       vertexShaderBody = (glslShader as any as ISingleShader).getVertexShaderBody({ getters: vertexPropertiesStr, definitions: definitions, matricesGetters: vertexShaderMethodDefinitions_uniform });
       pixelShaderBody = (glslShader as any as ISingleShader).getPixelShaderBody({ getters: pixelPropertiesStr, definitions: definitions, materialNode: materialNode });

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -515,12 +515,14 @@ export default class Material extends RnObject {
           getters: vertexPropertiesStr,
           definitions: definitions,
           dataUBODefinition: webglResourceRepository.getGlslDataUBODefinitionString(),
+          dataUBOVec4Size: webglResourceRepository.getGlslDataUBOVec4SizeString(),
           matricesGetters: vertexShaderMethodDefinitions_uniform
         })
       pixelShaderBody = ShaderityUtility.getInstance().getPixelShaderBody(materialNode.pixelShaderityObject!, {
         getters: pixelPropertiesStr,
         definitions: definitions,
-        dataUBODefinition: webglResourceRepository.getGlslDataUBODefinitionString()
+        dataUBODefinition: webglResourceRepository.getGlslDataUBODefinitionString(),
+        dataUBOVec4Size: webglResourceRepository.getGlslDataUBOVec4SizeString()
       });
     } else {
       vertexShaderBody = (glslShader as any as ISingleShader).getVertexShaderBody({ getters: vertexPropertiesStr, definitions: definitions, matricesGetters: vertexShaderMethodDefinitions_uniform });

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -470,7 +470,9 @@ export default class Material extends RnObject {
       definitions += '#version 300 es\n#define GLSL_ES3\n';
     }
     definitions += `#define RN_MATERIAL_TYPE_NAME ${this.__materialTypeName}\n`;
-    if (System.getInstance().processApproach === ProcessApproach.FastestWebGL1) {
+    if (System.getInstance().processApproach === ProcessApproach.FastestWebGL1 ||
+      System.getInstance().processApproach === ProcessApproach.FastestWebGL2
+    ) {
       definitions += '#define RN_IS_FASTEST_MODE\n';
     }
     if (glw.webgl1ExtSTL) {

--- a/src/foundation/materials/core/ShaderityUtility.ts
+++ b/src/foundation/materials/core/ShaderityUtility.ts
@@ -17,6 +17,12 @@ import MutableMatrix44 from "../../math/MutableMatrix44";
 import AbstractMaterialNode from "./AbstractMaterialNode";
 import { ShaderVariableUpdateInterval } from "../../definitions/ShaderVariableUpdateInterval";
 
+export type FillArgsObject = {
+  [s:string]: string,
+  WellKnownComponentTIDs?: any,
+  Config?: any
+};
+
 export default class ShaderityUtility {
   static __instance: ShaderityUtility;
   private __shaderity = Shaderity.getInstance();
@@ -36,13 +42,20 @@ export default class ShaderityUtility {
     return this.__instance;
   }
 
-  getVertexShaderBody(shaderityObject: ShaderityObject, args: any) {
-    const obj = this.__shaderity.fillTemplate(shaderityObject, {
-      definitions: (typeof args.definitions !== 'undefined') ? args.definitions : '',
-      matricesGetters: (typeof args.matricesGetters !== 'undefined') ? args.matricesGetters : '',
-      getters: (typeof args.getters !== 'undefined') ? args.getters : '',
-      WellKnownComponentTIDs: WellKnownComponentTIDs
+  private __removeNonStringProperties(args: FillArgsObject): FillArgsObject{
+    Object.keys(args).forEach(function(key) {
+      if (typeof args[key] !== 'string') {
+        args[key] = '';
+      }
     });
+
+    return args;
+  }
+
+  getVertexShaderBody(shaderityObject: ShaderityObject, args: FillArgsObject) {
+    let _args = this.__removeNonStringProperties(args);
+    _args.WellKnownComponentTIDs = WellKnownComponentTIDs;
+    const obj = this.__shaderity.fillTemplate(shaderityObject, _args);
 
     const isWebGL2 = this.__webglResourceRepository?.currentWebGLContextWrapper?.isWebGL2;
     const code = this.__shaderity.transformTo(isWebGL2 ? 'WebGL2' : 'WebGL1', obj).code;
@@ -50,13 +63,11 @@ export default class ShaderityUtility {
     return code;
   }
 
-  getPixelShaderBody(shaderityObject: ShaderityObject, args: any) {
-    const obj = this.__shaderity.fillTemplate(shaderityObject, {
-      definitions: (typeof args.definitions !== 'undefined') ? args.definitions : '',
-      getters: (typeof args.getters !== 'undefined') ? args.getters : '',
-      Config: Config,
-      WellKnownComponentTIDs: WellKnownComponentTIDs
-    });
+  getPixelShaderBody(shaderityObject: ShaderityObject, args: FillArgsObject) {
+    let _args = this.__removeNonStringProperties(args);
+    _args.WellKnownComponentTIDs = WellKnownComponentTIDs;
+    _args.Config = Config;
+    const obj = this.__shaderity.fillTemplate(shaderityObject, _args);
     const isWebGL2 = this.__webglResourceRepository?.currentWebGLContextWrapper?.isWebGL2;
     const code = this.__shaderity.transformTo(isWebGL2 ? 'WebGL2' : 'WebGL1', obj).code;
 

--- a/src/foundation/materials/core/ShaderityUtility.ts
+++ b/src/foundation/materials/core/ShaderityUtility.ts
@@ -16,6 +16,7 @@ import MutableMatrix33 from "../../math/MutableMatrix33";
 import MutableMatrix44 from "../../math/MutableMatrix44";
 import AbstractMaterialNode from "./AbstractMaterialNode";
 import { ShaderVariableUpdateInterval } from "../../definitions/ShaderVariableUpdateInterval";
+import MemoryManager from "../../core/MemoryManager";
 
 export type FillArgsObject = {
   [s:string]: string,
@@ -55,8 +56,9 @@ export default class ShaderityUtility {
   getVertexShaderBody(shaderityObject: ShaderityObject, args: FillArgsObject) {
     let _args = this.__removeNonStringProperties(args);
     _args.WellKnownComponentTIDs = WellKnownComponentTIDs;
+    _args.widthOfDataTexture = `const int widthOfDataTexture = ${MemoryManager.bufferWidthLength};`;
+    _args.heightOfDataTexture = `const int heightOfDataTexture = ${MemoryManager.bufferHeightLength};`;
     const obj = this.__shaderity.fillTemplate(shaderityObject, _args);
-
     const isWebGL2 = this.__webglResourceRepository?.currentWebGLContextWrapper?.isWebGL2;
     const code = this.__shaderity.transformTo(isWebGL2 ? 'WebGL2' : 'WebGL1', obj).code;
 
@@ -66,6 +68,8 @@ export default class ShaderityUtility {
   getPixelShaderBody(shaderityObject: ShaderityObject, args: FillArgsObject) {
     let _args = this.__removeNonStringProperties(args);
     _args.WellKnownComponentTIDs = WellKnownComponentTIDs;
+    _args.widthOfDataTexture = `const int widthOfDataTexture = ${MemoryManager.bufferWidthLength};`;
+    _args.heightOfDataTexture = `const int heightOfDataTexture = ${MemoryManager.bufferHeightLength};`;
     _args.Config = Config;
     const obj = this.__shaderity.fillTemplate(shaderityObject, _args);
     const isWebGL2 = this.__webglResourceRepository?.currentWebGLContextWrapper?.isWebGL2;

--- a/src/foundation/memory/Buffer.ts
+++ b/src/foundation/memory/Buffer.ts
@@ -3,17 +3,18 @@ import BufferView from "./BufferView";
 import { Byte, Size } from "../../commontypes/CommonTypes";
 
 export default class Buffer extends RnObject {
-  private __byteLength: Size = 0;
-  private __byteOffset: Size = 0;
+  private __byteLength: Byte = 0;
+  private __byteOffset: Byte = 0;
   private __raw: ArrayBuffer;
   private __name: string = '';
   private __takenBytesIndex: Byte = 0;
   private __bufferViews: Array<BufferView> = [];
 
-  constructor({byteLength, buffer, name} : {byteLength: Size, buffer: ArrayBuffer | Uint8Array, name: string}) {
+  constructor({byteLength, buffer, name} : {byteLength: Byte, buffer: ArrayBuffer, name: string}) {
     super();
     this.__name = name;
     this.__byteLength = byteLength;
+
     if (buffer instanceof Uint8Array) {
       this.__raw = buffer.buffer
       this.__byteOffset = buffer.byteOffset;

--- a/src/foundation/misc/MiscUtil.ts
+++ b/src/foundation/misc/MiscUtil.ts
@@ -56,7 +56,7 @@ const isNode = function () {
   return (typeof process !== "undefined" && typeof require !== "undefined");
 }
 
-const concatArrayBuffers = function (segments: ArrayBuffer[], sizes: Byte[], paddingSize: Byte) {
+const concatArrayBuffers = function (segments: ArrayBuffer[], sizes: Byte[], offsets: Byte[], paddingSize: Byte) {
   var sumLength = 0;
   for (var i = 0; i < sizes.length; ++i) {
     sumLength += sizes[i];
@@ -64,7 +64,7 @@ const concatArrayBuffers = function (segments: ArrayBuffer[], sizes: Byte[], pad
   var whole = new Uint8Array(sumLength + paddingSize);
   var pos = 0;
   for (var i = 0; i < segments.length; ++i) {
-    whole.set(new Uint8Array(segments[i], 0, sizes[i]), pos);
+    whole.set(new Uint8Array(segments[i+offsets[i]], 0, sizes[i]), pos);
     pos += sizes[i];
   }
   return whole.buffer;

--- a/src/webgl/WebGLResourceRepository.ts
+++ b/src/webgl/WebGLResourceRepository.ts
@@ -1394,6 +1394,31 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     gl.deleteBuffer(ubo);
   }
 
+  setupUniformBufferDataArea(typedArray?: TypedArray) {
+    const gl = this.__glw!.getRawContext();
+
+    if (gl == null) {
+      new Error("No WebGLRenderingContext set as Default.");
+    }
+
+    const ubo = gl.createBuffer();
+    const resourceHandle = this.getResourceNumber();
+    this.__webglResources.set(resourceHandle, ubo!);
+
+    const alignedMaxUniformBlockSize = this.__glw!.getAlignedMaxUniformBlockSize();
+    const array = typedArray ? typedArray : new Float32Array(alignedMaxUniformBlockSize / 4);
+    gl.bindBuffer(gl.UNIFORM_BUFFER, ubo);
+    gl.bufferData(gl.UNIFORM_BUFFER, array, gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.UNIFORM_BUFFER, null);
+
+    const maxConventionblocks = this.__glw!.getMaxConventionUniformBlocks();
+    for (let i=0; i<maxConventionblocks; i++) {
+      gl.bindBufferRange(gl.UNIFORM_BUFFER, i, ubo, alignedMaxUniformBlockSize * i, alignedMaxUniformBlockSize);
+    }
+    
+    return resourceHandle;
+  }
+
   createTransformFeedback() {
     const gl = this.__glw!.getRawContext();
     var transformFeedback = gl.createTransformFeedback();

--- a/src/webgl/WebGLResourceRepository.ts
+++ b/src/webgl/WebGLResourceRepository.ts
@@ -20,7 +20,7 @@ import Vector4 from "../foundation/math/Vector4";
 import { RenderBufferTarget } from "../foundation/definitions/RenderBufferTarget";
 import RenderPass from "../foundation/renderer/RenderPass";
 import { MiscUtil } from "../foundation/misc/MiscUtil";
-import { WebGLResourceHandle, TypedArray, Index, Size, Count, CGAPIResourceHandle } from "../commontypes/CommonTypes";
+import { WebGLResourceHandle, TypedArray, Index, Size, Count, CGAPIResourceHandle, Byte } from "../commontypes/CommonTypes";
 import DataUtil from "../foundation/misc/DataUtil";
 import RenderBuffer from "../foundation/textures/RenderBuffer";
 import { BasisFile } from "../commontypes/BasisTexture";
@@ -1346,12 +1346,12 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     return resourceHandle;
   }
 
-  updateUniformBuffer(uboUid: WebGLResourceHandle, bufferView: TypedArray | DataView) {
+  updateUniformBuffer(uboUid: WebGLResourceHandle, arrayBuffer: ArrayBuffer, offsetByte: Byte, byteLength: Byte) {
     const gl = this.__glw!.getRawContext();
     const ubo = this.getWebGLResource(uboUid);
 
     gl.bindBuffer(gl.UNIFORM_BUFFER, ubo);
-    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, bufferView, 0);
+    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, arrayBuffer, offsetByte, byteLength);
     gl.bindBuffer(gl.UNIFORM_BUFFER, null);
   }
 
@@ -1394,7 +1394,7 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     gl.deleteBuffer(ubo);
   }
 
-  setupUniformBufferDataArea(typedArray?: TypedArray) {
+  setupUniformBufferDataArea(arrayBuffer?: ArrayBuffer) {
     const gl = this.__glw!.getRawContext();
 
     if (gl == null) {
@@ -1406,9 +1406,9 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     this.__webglResources.set(resourceHandle, ubo!);
 
     const alignedMaxUniformBlockSize = this.__glw!.getAlignedMaxUniformBlockSize();
-    const array = typedArray ? typedArray : new Float32Array(alignedMaxUniformBlockSize / 4);
+    const array = arrayBuffer ? arrayBuffer : new Float32Array(alignedMaxUniformBlockSize / 4);
     gl.bindBuffer(gl.UNIFORM_BUFFER, ubo);
-    gl.bufferData(gl.UNIFORM_BUFFER, array, gl.DYNAMIC_DRAW);
+    gl.bufferData(gl.UNIFORM_BUFFER, array, gl.DYNAMIC_DRAW, 0, alignedMaxUniformBlockSize);
     gl.bindBuffer(gl.UNIFORM_BUFFER, null);
 
     const maxConventionblocks = this.__glw!.getMaxConventionUniformBlocks();

--- a/src/webgl/WebGLResourceRepository.ts
+++ b/src/webgl/WebGLResourceRepository.ts
@@ -1419,6 +1419,20 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     return resourceHandle;
   }
 
+  getGlslDataUBODefinitionString() {
+    let text = '';
+    const maxConventionblocks = this.__glw!.getMaxConventionUniformBlocks();
+    const alignedMaxUniformBlockSize = this.__glw!.getAlignedMaxUniformBlockSize();
+    for (let i=0; i<maxConventionblocks; i++) {
+      text += `
+layout (std140) uniform Vec4Block${i} {
+  vec4 vec4Data${i}[${alignedMaxUniformBlockSize/4/4}];
+};
+`    
+    }
+    return text;
+  }
+
   createTransformFeedback() {
     const gl = this.__glw!.getRawContext();
     var transformFeedback = gl.createTransformFeedback();

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -76,7 +76,7 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
   vec3 get_position(float vertexId, vec3 basePosition) {
     vec3 position = basePosition;
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
-      int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
+      int index = int(u_dataTextureMorphOffsetPosition[i]) + 1 * int(vertexId);
       vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -60,8 +60,6 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
   mat4 get_worldMatrix(float instanceId)
   {
     int index = ${Component.getLocationOffsetOfMemberOfComponent(SceneGraphComponent, 'worldMatrix')} + 4 * int(instanceId);
-    int widthOfDataTexture = ${MemoryManager.bufferWidthLength};
-    int heightOfDataTexture = ${MemoryManager.bufferHeightLength};
     mat4 matrix = fetchMat4(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture);
 
     return matrix;
@@ -70,8 +68,6 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
 
   mat3 get_normalMatrix(float instanceId) {
     int index = ${Component.getLocationOffsetOfMemberOfComponent(SceneGraphComponent, 'normalMatrix')} + 3 * int(instanceId);
-    int widthOfDataTexture = ${MemoryManager.bufferWidthLength};
-    int heightOfDataTexture = ${MemoryManager.bufferHeightLength};
     mat3 matrix = fetchMat3(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture);
     return matrix;
   }
@@ -81,8 +77,6 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
     vec3 position = basePosition;
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
       int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
-      int widthOfDataTexture = ${MemoryManager.bufferWidthLength};
-      int heightOfDataTexture = ${MemoryManager.bufferHeightLength};
       vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {
@@ -273,8 +267,6 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
 ${returnType} get_${methodName}(highp float _instanceId, const int index) {
   int instanceId = int(_instanceId);
   ${indexStr}
-  int widthOfDataTexture = ${MemoryManager.bufferWidthLength};
-  int heightOfDataTexture = ${MemoryManager.bufferHeightLength};
   `;
     }
 

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -461,9 +461,9 @@ ${returnType} get_${methodName}(highp float _instanceId, const int index) {
       const memoryManager: MemoryManager = MemoryManager.getInstance();
       const buffer: Buffer | undefined = memoryManager.getBuffer(BufferUse.GPUInstanceData);
       if (this.__dataUBOUid === CGAPIResourceRepository.InvalidCGAPIResourceUid) {
-        this.__dataUBOUid = this.__webglResourceRepository.setupUniformBufferDataArea(buffer!.getArrayBuffer());
+        this.__dataUBOUid = this.__webglResourceRepository.setupUniformBufferDataArea(new Float32Array(buffer!.getArrayBuffer()));
       } else {
-        this.__webglResourceRepository.updateUniformBuffer(this.__dataUBOUid, buffer!.getArrayBuffer(), 0, alignedMaxUniformBlockSize);
+        this.__webglResourceRepository.updateUniformBuffer(this.__dataUBOUid, new Float32Array(buffer!.getArrayBuffer()), 0, alignedMaxUniformBlockSize);
       }
     }
   }

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -42,6 +42,7 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
   private static __instance: WebGLStrategyFastest;
   private __webglResourceRepository: WebGLResourceRepository = WebGLResourceRepository.getInstance();
   private __dataTextureUid: CGAPIResourceHandle = CGAPIResourceRepository.InvalidCGAPIResourceUid;
+  private __dataUBOUid: CGAPIResourceHandle = CGAPIResourceRepository.InvalidCGAPIResourceUid;
   private __lastShader: CGAPIResourceHandle = CGAPIResourceRepository.InvalidCGAPIResourceUid;
   private __lastMaterial?: Material;
   private static __shaderProgram: WebGLProgram;
@@ -491,10 +492,17 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
 
     // Setup Data Texture
     this.__createAndUpdateDataTexture();
+    this.__createAndUpdateUBO();
 
     const componentRepository = ComponentRepository.getInstance();
     this.__lightComponents = componentRepository.getComponentsWithType(LightComponent) as LightComponent[];
 
+  }
+
+  private __createAndUpdateUBO() {
+    if (this.__webglResourceRepository.currentWebGLContextWrapper!.isWebGL2 && this.__dataUBOUid === CGAPIResourceRepository.InvalidCGAPIResourceUid) {
+      this.__dataUBOUid = this.__webglResourceRepository.setupUniformBufferDataArea();
+    }
   }
 
   attachGPUData(primitive: Primitive): void {

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -38,8 +38,8 @@ import ModuleManager from "../foundation/system/ModuleManager";
 import { RnXR } from "../rhodonite-xr";
 import Vector4 from "../foundation/math/Vector4";
 
-export default class WebGLStrategyFastestWebGL1 implements WebGLStrategy {
-  private static __instance: WebGLStrategyFastestWebGL1;
+export default class WebGLStrategyFastest implements WebGLStrategy {
+  private static __instance: WebGLStrategyFastest;
   private __webglResourceRepository: WebGLResourceRepository = WebGLResourceRepository.getInstance();
   private __dataTextureUid: CGAPIResourceHandle = CGAPIResourceRepository.InvalidCGAPIResourceUid;
   private __lastShader: CGAPIResourceHandle = CGAPIResourceRepository.InvalidCGAPIResourceUid;
@@ -233,7 +233,7 @@ export default class WebGLStrategyFastestWebGL1 implements WebGLStrategy {
       if (Math.abs(propertyIndex) % ShaderSemanticsClass._scale !== 0) {
         return '';
       }
-      const offset = WebGLStrategyFastestWebGL1.__getOffsetOfShaderSemanticsInfo(info);
+      const offset = WebGLStrategyFastest.__getOffsetOfShaderSemanticsInfo(info);
       for (let i = 0; i < info.maxIndex!; i++) {
         const index = Material.getLocationOffsetOfMemberOfMaterial(materialTypeName, propertyIndex)!;
         indexArray.push(index)
@@ -262,7 +262,7 @@ export default class WebGLStrategyFastestWebGL1 implements WebGLStrategy {
           }`;
       }
     } else {
-      const typeSize = WebGLStrategyFastestWebGL1.__getOffsetOfShaderSemanticsInfo(info);
+      const typeSize = WebGLStrategyFastest.__getOffsetOfShaderSemanticsInfo(info);
       let dataBeginPos = -1;
       if (isGlobalData) {
         const globalDataRepository = GlobalDataRepository.getInstance();
@@ -377,7 +377,7 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
       return;
     }
 
-    WebGLStrategyFastestWebGL1.__currentComponentSIDs = WebGLStrategyFastestWebGL1.__globalDataRepository.getValue(ShaderSemantics.CurrentComponentSIDs, 0);
+    WebGLStrategyFastest.__currentComponentSIDs = WebGLStrategyFastest.__globalDataRepository.getValue(ShaderSemantics.CurrentComponentSIDs, 0);
 
     if (!WebGLStrategyCommonMethod.isMaterialsSetup(meshComponent)) {
       this.setupShaderProgram(meshComponent);
@@ -546,7 +546,7 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
 
   static getInstance() {
     if (!this.__instance) {
-      this.__instance = new (WebGLStrategyFastestWebGL1)();
+      this.__instance = new (WebGLStrategyFastest)();
     }
 
     return this.__instance;
@@ -570,16 +570,16 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
     if (isVRMainPass) {
       const rnXRModule = ModuleManager.getInstance().getModule('xr') as RnXR;
       const webvrSystem = rnXRModule.WebVRSystem.getInstance();
-      WebGLStrategyFastestWebGL1.__currentComponentSIDs!.v[WellKnownComponentTIDs.CameraComponentTID] = webvrSystem.getCameraComponentSIDAt(displayIdx);
+      WebGLStrategyFastest.__currentComponentSIDs!.v[WellKnownComponentTIDs.CameraComponentTID] = webvrSystem.getCameraComponentSIDAt(displayIdx);
     } else {
       let cameraComponent = renderPass.cameraComponent;
       if (cameraComponent == null) {
         cameraComponent = ComponentRepository.getInstance().getComponent(CameraComponent, CameraComponent.main) as CameraComponent;
       }
       if (cameraComponent) {
-        WebGLStrategyFastestWebGL1.__currentComponentSIDs!.v[WellKnownComponentTIDs.CameraComponentTID] = cameraComponent.componentSID;
+        WebGLStrategyFastest.__currentComponentSIDs!.v[WellKnownComponentTIDs.CameraComponentTID] = cameraComponent.componentSID;
       } else {
-        WebGLStrategyFastestWebGL1.__currentComponentSIDs!.v[WellKnownComponentTIDs.CameraComponentTID] = -1;
+        WebGLStrategyFastest.__currentComponentSIDs!.v[WellKnownComponentTIDs.CameraComponentTID] = -1;
       }
     }
   }
@@ -592,15 +592,15 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
       if (skeletalComponent.componentSID < Config.maxSkeletonNumber) {
         index = skeletalComponent.componentSID;
       }
-      WebGLStrategyFastestWebGL1.__currentComponentSIDs!.v[WellKnownComponentTIDs.SkeletalComponentTID] = index;
+      WebGLStrategyFastest.__currentComponentSIDs!.v[WellKnownComponentTIDs.SkeletalComponentTID] = index;
     } else {
-      WebGLStrategyFastestWebGL1.__currentComponentSIDs!.v[WellKnownComponentTIDs.SkeletalComponentTID] = -1;
+      WebGLStrategyFastest.__currentComponentSIDs!.v[WellKnownComponentTIDs.SkeletalComponentTID] = -1;
     }
   }
 
   private __setCurrentComponentSIDsForEachPrimitive(gl: WebGLRenderingContext, renderPass: RenderPass, material: Material, entity: Entity) {
-    WebGLStrategyFastestWebGL1.__currentComponentSIDs!.v[0] = material.materialSID;
-    gl.uniform1fv((WebGLStrategyFastestWebGL1.__shaderProgram as any).currentComponentSIDs, WebGLStrategyFastestWebGL1.__currentComponentSIDs!.v);
+    WebGLStrategyFastest.__currentComponentSIDs!.v[0] = material.materialSID;
+    gl.uniform1fv((WebGLStrategyFastest.__shaderProgram as any).currentComponentSIDs, WebGLStrategyFastest.__currentComponentSIDs!.v);
   }
 
   private __getDisplayNumber(isVRMainPass: boolean) {
@@ -669,7 +669,7 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
 
             this.__webglResourceRepository.bindTexture2D(7, this.__dataTextureUid);
 
-            WebGLStrategyFastestWebGL1.__shaderProgram = shaderProgram;
+            WebGLStrategyFastest.__shaderProgram = shaderProgram;
             firstTime = true;
           }
           if (this.__lastMaterial !== material) {
@@ -682,7 +682,7 @@ ${returnType} get_${methodName}(highp float instanceId, const int index) {
           WebGLStrategyCommonMethod.setCullAndBlendSettings(material, renderPass, gl);
 
           material.setParametersForGPU({
-            material: material, shaderProgram: WebGLStrategyFastestWebGL1.__shaderProgram, firstTime: firstTime,
+            material: material, shaderProgram: WebGLStrategyFastest.__shaderProgram, firstTime: firstTime,
             args: {
               glw: glw,
               entity: entity,

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -217,9 +217,8 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
 
     const methodName = info.semantic.str.replace('.', '_');
 
-    // definition of uniform variable
+    // definition of uniform variable for texture sampler or what must be explicitly uniform variabl)
     let varDef = '';
-    //      if (isTexture) {
     const varType = info.compositionType.getGlslStr(info.componentType);
     let varIndexStr = '';
     if (info.maxIndex) {
@@ -228,7 +227,7 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
     if (info.needUniformInFastest || isTexture) {
       varDef = `  uniform ${varType} u_${methodName}${varIndexStr};\n`;
     }
-    //    }
+
     // inner contents of 'get_' shader function
     if (propertyIndex < 0) {
       if (Math.abs(propertyIndex) % ShaderSemanticsClass._scale !== 0) {

--- a/src/webgl/WebGLStrategyUniform.ts
+++ b/src/webgl/WebGLStrategyUniform.ts
@@ -140,12 +140,8 @@ mat3 get_normalMatrix(float instanceId) {
   vec3 get_position(float vertexId, vec3 basePosition) {
     vec3 position = basePosition;
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
-      float index = u_dataTextureMorphOffsetPosition[i] + 1.0 * vertexId;
-      float powWidthVal = ${MemoryManager.bufferWidthLength}.0;
-      float powHeightVal = ${MemoryManager.bufferHeightLength}.0;
-      vec2 arg = vec2(1.0/powWidthVal, 1.0/powHeightVal);
-    //  vec2 arg = vec2(1.0/powWidthVal, 1.0/powWidthVal/powHeightVal);
-      vec3 addPos = fetchElement(u_dataTexture, index + 0.0, arg).xyz;
+      int index = int(u_dataTextureMorphOffsetPosition[i]) + 1 * int(vertexId);
+      vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {
         break;

--- a/src/webgl/WebGLStrategyUniform.ts
+++ b/src/webgl/WebGLStrategyUniform.ts
@@ -258,7 +258,11 @@ mat3 get_normalMatrix(float instanceId) {
       if ((buffer.takenSizeInByte) / 4 / 4 < MemoryManager.bufferWidthLength * MemoryManager.bufferHeightLength) {
         paddingArrayBufferSize = MemoryManager.bufferWidthLength * MemoryManager.bufferHeightLength * 4 * 4 - buffer.takenSizeInByte;
       }
-      const concatArrayBuffer = MiscUtil.concatArrayBuffers([buffer.getArrayBuffer()], [buffer.takenSizeInByte], paddingArrayBufferSize);
+      const concatArrayBuffer = MiscUtil.concatArrayBuffers(
+        [buffer.getArrayBuffer()],
+        [buffer.takenSizeInByte],
+        [0],
+        paddingArrayBufferSize);
       const floatDataTextureBuffer = new Float32Array(concatArrayBuffer);
 
       if (this.__webglResourceRepository.currentWebGLContextWrapper!.isWebGL2) {

--- a/src/webgl/getRenderingStrategy.ts
+++ b/src/webgl/getRenderingStrategy.ts
@@ -1,14 +1,14 @@
 import { ProcessApproach, ProcessApproachEnum } from "../foundation/definitions/ProcessApproach";
 import WebGLStrategy from "./WebGLStrategy";
 import WebGLStrategyUniform from "./WebGLStrategyUniform";
-import WebGLStrategyFastestWebGL1 from "./WebGLStrategyFastestWebGL1";
+import WebGLStrategyFastest from "./WebGLStrategyFastest";
 
 const getRenderingStrategy = function (processApproach: ProcessApproachEnum): WebGLStrategy {
   // Strategy
   if (processApproach.index === ProcessApproach.FastestWebGL1.index || 
       processApproach.index === ProcessApproach.FastestWebGL2.index
     ) {
-    return WebGLStrategyFastestWebGL1.getInstance();
+    return WebGLStrategyFastest.getInstance();
   } else if (processApproach.index === ProcessApproach.UniformWebGL1.index ||
     processApproach.index === ProcessApproach.UniformWebGL2.index) {
     return WebGLStrategyUniform.getInstance();

--- a/src/webgl/shaderity_shaders/common/prerequisites.glsl
+++ b/src/webgl/shaderity_shaders/common/prerequisites.glsl
@@ -1,5 +1,8 @@
 uniform float u_materialSID; // skipProcess=true
 uniform sampler2D u_dataTexture; // skipProcess=true
+/* shaderity: @{widthOfDataTexture} */
+/* shaderity: @{heightOfDataTexture} */
+
 #if defined(GLSL_ES3) && defined(RN_IS_FASTEST_MODE)
 /* shaderity: @{dataUBODefinition} */
 #endif

--- a/src/webgl/shaderity_shaders/common/prerequisites.glsl
+++ b/src/webgl/shaderity_shaders/common/prerequisites.glsl
@@ -1,5 +1,9 @@
 uniform float u_materialSID; // skipProcess=true
 uniform sampler2D u_dataTexture; // skipProcess=true
+#ifdef GLSL_ES3
+// /* shaderity: @{dataUBODefinition} */
+#endif
+
 
   /*
   * This idea from https://qiita.com/YVT/items/c695ab4b3cf7faa93885

--- a/src/webgl/shaderity_shaders/common/prerequisites.glsl
+++ b/src/webgl/shaderity_shaders/common/prerequisites.glsl
@@ -1,7 +1,7 @@
 uniform float u_materialSID; // skipProcess=true
 uniform sampler2D u_dataTexture; // skipProcess=true
 #ifdef GLSL_ES3
-// /* shaderity: @{dataUBODefinition} */
+/* shaderity: @{dataUBODefinition} */
 #endif
 
 

--- a/src/webgl/shaders/GLSLShader.ts
+++ b/src/webgl/shaders/GLSLShader.ts
@@ -370,7 +370,7 @@ bool processGeometryWithMorphingAndSkinning(
     const dataUboDefinition = webGLResourceRepository.getGlslDataUBODefinitionString();
     return `uniform float u_materialSID;
 uniform sampler2D u_dataTexture;
-#ifdef GLSL_ES3
+#if defined(GLSL_ES3) && defined(RN_IS_FASTEST_MODE)
   ${dataUboDefinition}
 #endif
 
@@ -383,19 +383,79 @@ uniform sampler2D u_dataTexture;
   //   return ${this.glsl_texture}( tex, arg * (index + 0.5) );
   // }
 
-highp vec4 fetchElement(highp sampler2D tex, highp float index, highp vec2 invSize){
-  highp float t = (index + 0.5) * invSize.x;
+// highp vec4 fetchElement(highp sampler2D tex, highp float index, highp vec2 invSize){
+//   highp float t = (index + 0.5) * invSize.x;
+//   highp float x = fract(t);
+//   highp float y = (floor(t) + 0.5) * invSize.y;
+//   return ${this.glsl_texture}( tex, vec2(x, y) );
+// }
+
+// #ifdef GLSL_ES3
+// highp vec4 fetchElement(highp sampler2D tex, highp int index, highp int width){
+//   highp ivec2 uv = ivec2(index % width, index / width);
+//   return texelFetch( tex, uv, 0 );
+// }
+// #endif
+
+highp vec4 fetchElement(highp sampler2D tex, int index, int texWidth, int texHeight) {
+#ifdef GLSL_ES3
+  highp ivec2 uv = ivec2(index % texWidth, index / texWidth);
+  return texelFetch( tex, uv, 0 );
+#else
+  highp vec2 invSize = vec2(1.0/float(texWidth), 1.0/float(texHeight));
+  highp float t = (float(index) + 0.5) * invSize.x;
   highp float x = fract(t);
   highp float y = (floor(t) + 0.5) * invSize.y;
   return ${this.glsl_texture}( tex, vec2(x, y) );
+#endif
 }
 
-#ifdef GLSL_ES3
-highp vec4 fetchElement(highp sampler2D tex, highp int index, highp int width){
-  highp ivec2 uv = ivec2(index % width, index / width);
-  return texelFetch( tex, uv, 0 );
+vec4 fetchVec4(highp sampler2D tex, int idx, int texWidth, int texHeight) {
+  vec4 val = fetchElement(u_dataTexture, idx, texWidth, texHeight);
+
+  return val;
 }
-#endif
+
+mat2 fetchMat2(highp sampler2D tex, int idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
+
+  mat2 val = mat2(
+    col0.x, col0.y,
+    col0.z, col0.w
+    );
+  
+  return val;
+}
+
+mat3 fetchMat3(highp sampler2D tex, int idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
+  vec4 col1 = fetchElement(u_dataTexture, idx + 1, texWidth, texHeight);
+  vec4 col2 = fetchElement(u_dataTexture, idx + 2, texWidth, texHeight);
+
+  mat3 val = mat3(
+    col0.x, col0.y, col0.z,
+    col0.w, col1.x, col1.y,
+    col1.z, col1.w, col2.x
+    );
+
+  return val;
+}
+
+mat4 fetchMat4(highp sampler2D tex, int idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
+  vec4 col1 = fetchElement(u_dataTexture, idx + 1, texWidth, texHeight);
+  vec4 col2 = fetchElement(u_dataTexture, idx + 2, texWidth, texHeight);
+  vec4 col3 = fetchElement(u_dataTexture, idx + 3, texWidth, texHeight);
+
+  mat4 val = mat4(
+    col0.x, col0.y, col0.z, col0.w,
+    col1.x, col1.y, col1.z, col1.w,
+    col2.x, col2.y, col2.z, col2.w,
+    col3.x, col3.y, col3.z, col3.w
+    );
+
+  return val;
+}
 
 float rand(const vec2 co){
   return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);

--- a/src/webgl/shaders/GLSLShader.ts
+++ b/src/webgl/shaders/GLSLShader.ts
@@ -366,8 +366,13 @@ bool processGeometryWithMorphingAndSkinning(
   }
 
   get prerequisites() {
+    const webGLResourceRepository = WebGLResourceRepository.getInstance();
+    const dataUboDefinition = webGLResourceRepository.getGlslDataUBODefinitionString();
     return `uniform float u_materialSID;
 uniform sampler2D u_dataTexture;
+#ifdef GLSL_ES3
+  ${dataUboDefinition}
+#endif
 
   /*
   * This idea from https://qiita.com/YVT/items/c695ab4b3cf7faa93885

--- a/src/webgl/shaders/GLSLShader.ts
+++ b/src/webgl/shaders/GLSLShader.ts
@@ -6,6 +6,7 @@ import { VertexAttributeEnum, VertexAttributeClass } from "../../foundation/defi
 import WebGLResourceRepository from "../WebGLResourceRepository";
 import { WellKnownComponentTIDs } from "../../foundation/components/WellKnownComponentTIDs";
 import SystemState from "../../foundation/system/SystemState";
+import MemoryManager from "../../foundation/core/MemoryManager";
 
 export type AttributeNames = Array<string>;
 
@@ -370,6 +371,9 @@ bool processGeometryWithMorphingAndSkinning(
     const dataUboDefinition = webGLResourceRepository.getGlslDataUBODefinitionString();
     return `uniform float u_materialSID;
 uniform sampler2D u_dataTexture;
+const int widthOfDataTexture = ${MemoryManager.bufferWidthLength};
+const int heightOfDataTexture = ${MemoryManager.bufferHeightLength};
+
 #if defined(GLSL_ES3) && defined(RN_IS_FASTEST_MODE)
   ${dataUboDefinition}
 #endif

--- a/src/webgl/shaders/GLSLShader.ts
+++ b/src/webgl/shaders/GLSLShader.ts
@@ -408,7 +408,8 @@ vec3 descramble(vec3 v) {
 
   get mainPrerequisites() {
     const processApproach = SystemState.currentProcessApproach;
-    if (processApproach === ProcessApproach.FastestWebGL1) {
+    if (processApproach === ProcessApproach.FastestWebGL1 ||
+      processApproach === ProcessApproach.FastestWebGL2) {
       return `
   float materialSID = u_currentComponentSIDs[0];
 


### PR DESCRIPTION
This PR's key points are:

- Support the property access to huge logical shader memory using UBO & DataTexture access in Rn.ProcessApproach.FastestWebGL2.
- The first part of Memory data in BufferUse.GPUInstanceData are stored the range of data that fits in the UBO, and store the rest in data textures.
- Each shader property getters don't need to worry about the boundaries of UBO and data texture.
- Others, such as refactoring

# Known problems
- It takes so long time to compile shaders in Rn.ProcessApproach.FastestWebGL2 mode currently. This may be due to the way the UBO blocks are defined in large numbers.