### PR TITLE
Add shader parameter getter like `fetchVec3No16BytesAligned`, which is not 16bytes aligned for byte offset calculation.

### DIFF
--- a/src/commontypes/CommonTypes.ts
+++ b/src/commontypes/CommonTypes.ts
@@ -5,6 +5,8 @@ export type TypedArrayConstructor = Int8ArrayConstructor | Uint8ArrayConstructor
 Uint16ArrayConstructor | Int32ArrayConstructor | Uint32ArrayConstructor | Float32ArrayConstructor | Float64ArrayConstructor;
 
 export type Index = number;
+export type IndexOf16Bytes = number;
+export type IndexOf4Bytes = number;
 export type Size = number;
 export type Count = number;
 export type Byte = number;

--- a/src/foundation/core/Component.ts
+++ b/src/foundation/core/Component.ts
@@ -254,7 +254,7 @@ export default class Component extends RnObject {
 
     const bufferViews = this.__bufferViews.get(componentClass)!;
     if (!bufferViews.has(bufferUse)) {
-      const bufferView = buffer.takeBufferView({ byteLengthToNeed: byteLengthSumOfMembers * count, byteStride: 0, isAoS: false, byteAlign: 16 });
+      const bufferView = buffer.takeBufferView({ byteLengthToNeed: byteLengthSumOfMembers * count, byteStride: 0, isAoS: false });
       bufferViews.set(bufferUse, bufferView);
       return bufferView;
     }

--- a/src/foundation/core/Config.ts
+++ b/src/foundation/core/Config.ts
@@ -13,7 +13,7 @@ let dataTextureWidth = Math.pow(2, 12);
 let dataTextureHeight = Math.pow(2, 12);
 let boneDataType = BoneDataType.Vec4x2;
 let noWebGLTex2DStateCache = false;
-let maxMorphTargetNumber = 38;
+let maxMorphTargetNumber = 4;
 let totalSizeOfGPUShaderDataStorageExceptMorphData = 0;
 
 export default {

--- a/src/foundation/core/Config.ts
+++ b/src/foundation/core/Config.ts
@@ -13,10 +13,11 @@ let dataTextureWidth = Math.pow(2, 12);
 let dataTextureHeight = Math.pow(2, 12);
 let boneDataType = BoneDataType.Vec4x2;
 let noWebGLTex2DStateCache = false;
+let maxMorphTargetNumber = 38;
 let totalSizeOfGPUShaderDataStorageExceptMorphData = 0;
 
 export default {
   maxEntityNumber, maxLightNumberInShader, maxVertexMorphNumberInShader, maxMaterialInstanceForEachType, boneDataType,
   maxSkeletonNumber, maxCameraNumber, maxSizeLimitOfNonCompressedTexture, maxSkeletalBoneNumber, dataTextureWidth, dataTextureHeight,
-  noWebGLTex2DStateCache, totalSizeOfGPUShaderDataStorageExceptMorphData
+  noWebGLTex2DStateCache, maxMorphTargetNumber, totalSizeOfGPUShaderDataStorageExceptMorphData
 };

--- a/src/foundation/core/GlobalDataRepository.ts
+++ b/src/foundation/core/GlobalDataRepository.ts
@@ -1,5 +1,5 @@
 import { ShaderSemanticsIndex, ShaderSemanticsInfo, ShaderSemanticsEnum, ShaderSemantics, getShaderPropertyFunc } from "../definitions/ShaderSemantics";
-import { Count, Index, CGAPIResourceHandle } from "../../commontypes/CommonTypes";
+import { Count, Index, CGAPIResourceHandle, IndexOf16Bytes } from "../../commontypes/CommonTypes";
 import { BufferUse } from "../definitions/BufferUse";
 import MemoryManager from "./MemoryManager";
 import { CompositionType } from "../definitions/CompositionType";
@@ -258,12 +258,12 @@ export default class GlobalDataRepository {
   //   return void 0;
   // }
 
-  getLocationOffsetOfProperty(propertyIndex: Index) {
+  getLocationOffsetOfProperty(propertyIndex: Index): IndexOf16Bytes {
     const globalPropertyStruct = this.__fields.get(propertyIndex);
     if (globalPropertyStruct) {
       return globalPropertyStruct.accessor.byteOffsetInBuffer / 4 / 4;
     }
-    return void 0;
+    return -1;
   }
 
 

--- a/src/foundation/core/GlobalDataRepository.ts
+++ b/src/foundation/core/GlobalDataRepository.ts
@@ -157,7 +157,6 @@ export default class GlobalDataRepository {
     const bufferView = buffer.takeBufferView({
       byteLengthToNeed: alignedByteLength * maxCount,
       byteStride: 0,
-      byteAlign: 16,
       isAoS: false
     });
 

--- a/src/foundation/core/MemoryManager.ts
+++ b/src/foundation/core/MemoryManager.ts
@@ -45,10 +45,17 @@ export default class MemoryManager {
   private __createBuffer(bufferUse: BufferUseEnum) {
     let memorySize = MemoryManager.bufferWidthLength * MemoryManager.bufferHeightLength/*width*height*/ * 4/*rgba*/ * 4/*byte*/ * this.__memorySizeRatios[bufferUse.str];
     const arrayBuffer = new ArrayBuffer(this.__makeMultipleOf4byteSize(memorySize));
+
+    let byteAlign = 4;
+    if (bufferUse == BufferUse.GPUInstanceData || bufferUse == BufferUse.GPUVertexData) {
+      byteAlign = 16;
+    }
+
     const buffer = new Buffer({
       byteLength: arrayBuffer.byteLength,
       buffer: arrayBuffer,
-      name: bufferUse.str
+      name: bufferUse.str,
+      byteAlign: byteAlign
     });
     this.__buffers[buffer.name] = buffer;
 
@@ -69,12 +76,13 @@ export default class MemoryManager {
     return buffer;
   }
 
-  createBufferOnDemand(size: Byte, object: RnObject) {
+  createBufferOnDemand(size: Byte, object: RnObject, byteAlign: Byte) {
     const arrayBuffer = new ArrayBuffer(size);
     const buffer = new Buffer({
       byteLength: arrayBuffer.byteLength,
       buffer: arrayBuffer,
-      name: BufferUse.UBOGeneric.toString()
+      name: BufferUse.UBOGeneric.toString(),
+      byteAlign: byteAlign
     });
     this.__buffersOnDemand.set(object.objectUID, buffer);
     return buffer;

--- a/src/foundation/definitions/CompositionType.ts
+++ b/src/foundation/definitions/CompositionType.ts
@@ -106,8 +106,16 @@ const Vec2Array: CompositionTypeEnum = new CompositionTypeClass({ index: 10, str
 const Vec3Array: CompositionTypeEnum = new CompositionTypeClass({ index: 11, str: 'VEC3_ARRAY', glslStr: 'vec3', hlslStr: 'float3', numberOfComponents: 3, isArray: true });
 const Vec4Array: CompositionTypeEnum = new CompositionTypeClass({ index: 12, str: 'VEC4_ARRAY', glslStr: 'vec4', hlslStr: 'float4', numberOfComponents: 4, isArray: true });
 const Mat4Array: CompositionTypeEnum = new CompositionTypeClass({ index: 13, str: 'MAT4_ARRAY', glslStr: 'mat4', hlslStr: 'float4x4', numberOfComponents: 16, isArray: true });
+const Mat3Array: CompositionTypeEnum = new CompositionTypeClass({ index: 14, str: 'MAT3_ARRAY', glslStr: 'mat3', hlslStr: 'float3x3', numberOfComponents: 9, isArray: true });
+const Mat2Array: CompositionTypeEnum = new CompositionTypeClass({ index: 15, str: 'MAT2_ARRAY', glslStr: 'mat2', hlslStr: 'float2x2', numberOfComponents: 4, isArray: true });
 
-const typeList = [Unknown, Scalar, Vec2, Vec3, Vec4, Mat2, Mat3, Mat4, Texture2D, TextureCube, ScalarArray, Vec2Array, Vec3Array, Vec4Array];
+const typeList = [
+  Unknown, Scalar, Vec2, Vec3, Vec4,
+  Mat2, Mat3, Mat4,
+  Vec2Array, Vec3Array, Vec4Array,
+  ScalarArray, Mat2Array, Mat3Array, Mat4Array,
+  Texture2D, TextureCube
+];
 
 function from(index: number): CompositionTypeEnum {
   return _from({ typeList, index }) as CompositionTypeEnum;
@@ -132,11 +140,19 @@ function fromGlslString(str_: string): CompositionTypeEnum {
 }
 
 function isArray(compositionType: CompositionTypeEnum) {
-  if (compositionType === ScalarArray || compositionType === Vec2Array || compositionType === Vec3Array || compositionType === Vec4Array || compositionType === Mat4Array) {
+  if (compositionType === ScalarArray || compositionType === Vec2Array || compositionType === Vec3Array || compositionType === Vec4Array ||
+    compositionType === Mat4Array || compositionType === Mat3Array || compositionType === Mat2Array) {
     return true;
   } else {
     return false;
   }
 }
 
-export const CompositionType = Object.freeze({ Unknown, Scalar, Vec2, Vec3, Vec4, Mat2, Mat3, Mat4, Texture2D, TextureCube, ScalarArray, Vec2Array, Vec3Array, Vec4Array, Mat4Array, from, fromString, fromGlslString, isArray });
+export const CompositionType = Object.freeze({
+  Unknown, Scalar, Vec2, Vec3, Vec4,
+  Mat2, Mat3, Mat4,
+  ScalarArray, Vec2Array, Vec3Array, Vec4Array,
+  Mat2Array, Mat3Array, Mat4Array,
+  Texture2D, TextureCube,
+  from, fromString, fromGlslString, isArray
+});

--- a/src/foundation/definitions/ShaderSemantics.ts
+++ b/src/foundation/definitions/ShaderSemantics.ts
@@ -132,11 +132,28 @@ type UpdateFunc = (
   => void;
 
 export type ShaderSemanticsInfo = {
-  semantic: ShaderSemanticsEnum, prefix?: string, index?: Count, maxIndex?: Count,
-  compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, min: number, max: number, valueStep?: number,
-  isSystem: boolean, initialValue?: any, updateInterval?: ShaderVariableUpdateIntervalEnum, stage: ShaderTypeEnum,
-  xName?: string, yName?: string, zName?: string, wName?: string, soloDatum?: boolean, isComponentData?: boolean, noControlUi?: boolean,
-  needUniformInFastest?: boolean, none_u_prefix?: boolean
+  semantic: ShaderSemanticsEnum,
+  prefix?: string,
+  index?: Count,
+  maxIndex?: Count,
+  compositionType: CompositionTypeEnum,
+  componentType: ComponentTypeEnum,
+  min: number,
+  max: number,
+  valueStep?: number,
+  isSystem: boolean,
+  initialValue?: any,
+  updateInterval?: ShaderVariableUpdateIntervalEnum,
+  stage: ShaderTypeEnum,
+  xName?: string,
+  yName?: string,
+  zName?: string,
+  wName?: string,
+  soloDatum?: boolean,
+  isComponentData?: boolean,
+  noControlUi?: boolean,
+  needUniformInFastest?: boolean,
+  none_u_prefix?: boolean
 };
 
 
@@ -225,6 +242,6 @@ export const ShaderSemantics = Object.freeze({
   DiffuseColorFactor, DiffuseColorTexture, SpecularColorFactor, SpecularColorTexture, Shininess, ShadingModel, SkinningMode, GeneralTexture,
   VertexAttributesExistenceArray, BoneQuaternion, BoneTranslateScale, BoneCompressedChunk, BoneCompressedInfo, PointSize, ColorEnvTexture, PointDistanceAttenuation,
   HDRIFormat, ScreenInfo, DepthTexture, LightViewProjectionMatrix, Anisotropy, ClearCoatParameter, SheenParameter, SpecularGlossinessFactor, SpecularGlossinessTexture,
-  fullSemanticStr, getShaderProperty, 
+  fullSemanticStr, getShaderProperty,
   EntityUID, MorphTargetNumber, DataTextureMorphOffsetPosition, MorphWeights, CurrentComponentSIDs, AlphaCutoff, AlphaTexture
 });

--- a/src/foundation/geometry/Plane.ts
+++ b/src/foundation/geometry/Plane.ts
@@ -89,7 +89,7 @@ export default class Plane extends Primitive {
     const indexSizeInByte = indices.length * 2;
 
     // Create Buffer
-    const buffer = MemoryManager.getInstance().createBufferOnDemand(indexSizeInByte + sumOfAttributesByteSize, this);
+    const buffer = MemoryManager.getInstance().createBufferOnDemand(indexSizeInByte + sumOfAttributesByteSize, this, 4);
 
 
     // Index Buffer
@@ -114,7 +114,7 @@ export default class Plane extends Primitive {
       const accessor: AccessorBase = attributesBufferView.takeAccessor({
         compositionType: attributeCompositionTypes[i],
         componentType: ComponentType.fromTypedArray(attributes[i]),
-        count: attribute.byteLength / attributeCompositionTypes[i].getNumberOfComponents() / attributeComponentTypes[i].getSizeInBytes()
+        count: attribute.byteLength / attributeCompositionTypes[i].getNumberOfComponents() / attributeComponentTypes[i].getSizeInBytes(),
       });
       accessor.copyFromTypedArray(attribute);
       attributeAccessors.push(accessor);

--- a/src/foundation/geometry/Primitive.ts
+++ b/src/foundation/geometry/Primitive.ts
@@ -142,7 +142,7 @@ export default class Primitive extends RnObject {
     }
 
     const primitive = new Primitive();
-    const buffer = MemoryManager.getInstance().createBufferOnDemand(bufferSize, primitive);
+    const buffer = MemoryManager.getInstance().createBufferOnDemand(bufferSize, primitive, 4);
 
     let indicesComponentType;
     let indicesBufferView;

--- a/src/foundation/geometry/Sphere.ts
+++ b/src/foundation/geometry/Sphere.ts
@@ -86,7 +86,7 @@ export default class Sphere extends Primitive {
     });
     const indexSizeInByte = indices.length * 2;
 
-    const buffer = MemoryManager.getInstance().createBufferOnDemand(indexSizeInByte + sumOfAttributesByteSize, this);
+    const buffer = MemoryManager.getInstance().createBufferOnDemand(indexSizeInByte + sumOfAttributesByteSize, this, 4);
 
     const indicesBufferView = buffer.takeBufferView({byteLengthToNeed: indexSizeInByte /*byte*/, byteStride: 0, isAoS: false});
     const indicesAccessor = indicesBufferView.takeAccessor({

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -1362,16 +1362,36 @@ export default class ModelConverter {
   }
 
   private __copyRnAccessorAndBufferView(srcRnAccessor: Accessor) {
-    const byteSize = srcRnAccessor.elementCount * 4 /* vec4 */ * 4 /* bytes */;
+    // const byteSize = srcRnAccessor.elementCount * 4 /* vec4 */ * 4 /* bytes */;
+    // const dstRnBuffer = MemoryManager.getInstance().createOrGetBuffer(BufferUse.GPUVertexData);
+    // const dstRnBufferView = dstRnBuffer.takeBufferView({
+    //   byteLengthToNeed: byteSize,
+    //   byteStride: 4 /* vec4 */ * 4 /* bytes */,
+    //   isAoS: false
+    // });
+
+    // const dstRnAccessor = dstRnBufferView.takeAccessor({
+    //   compositionType: CompositionType.Vec4,
+    //   componentType: ComponentType.Float,
+    //   count: srcRnAccessor.elementCount,
+    //   max: srcRnAccessor.max,
+    //   min: srcRnAccessor.min,
+    //   normalized: srcRnAccessor.normalized
+    // });
+    // for (let i = 0; i < srcRnAccessor.elementCount; i++) {
+    //   dstRnAccessor.setElementFromAccessor(i, srcRnAccessor);
+    // }
+
+    const byteSize = srcRnAccessor.elementCount * 3 /* vec4 */ * 4 /* bytes */;
     const dstRnBuffer = MemoryManager.getInstance().createOrGetBuffer(BufferUse.GPUVertexData);
     const dstRnBufferView = dstRnBuffer.takeBufferView({
       byteLengthToNeed: byteSize,
-      byteStride: 4 /* vec4 */ * 4 /* bytes */,
+      byteStride: 3 /* vec4 */ * 4 /* bytes */,
       isAoS: false
     });
 
     const dstRnAccessor = dstRnBufferView.takeAccessor({
-      compositionType: CompositionType.Vec4,
+      compositionType: CompositionType.Vec3,
       componentType: ComponentType.Float,
       count: srcRnAccessor.elementCount,
       max: srcRnAccessor.max,
@@ -1381,7 +1401,6 @@ export default class ModelConverter {
     for (let i = 0; i < srcRnAccessor.elementCount; i++) {
       dstRnAccessor.setElementFromAccessor(i, srcRnAccessor);
     }
-
     // dstRnAccessor.copyBuffer(srcRnAccessor);
 
     return dstRnAccessor;

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -544,7 +544,9 @@ export default class ModelConverter {
             for (let attributeName in target) {
               let attributeAccessor = target[attributeName] as Gltf2Accessor;
               const attributeRnAccessor = this.__getRnAccessor(attributeAccessor, rnBuffers[(attributeAccessor.bufferView as Gltf2BufferView).bufferIndex!]);
-              targetMap.set(VertexAttribute.fromString(attributeName), attributeRnAccessor);
+              // targetMap.set(VertexAttribute.fromString(attributeName), attributeRnAccessor);
+              const attributeRnAccessorInGPUVertexData = this.__copyRnAccessorAndBufferView(attributeRnAccessor);
+              targetMap.set(VertexAttribute.fromString(attributeName), attributeRnAccessorInGPUVertexData);
             }
             targets.push(targetMap);
           }
@@ -1379,6 +1381,8 @@ export default class ModelConverter {
     for (let i = 0; i < srcRnAccessor.elementCount; i++) {
       dstRnAccessor.setElementFromAccessor(i, srcRnAccessor);
     }
+
+    // dstRnAccessor.copyBuffer(srcRnAccessor);
 
     return dstRnAccessor;
   }

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -527,7 +527,7 @@ export default class ModelConverter {
         if (primitive.targets != null) {
 
           // set default number
-          let maxMorphTargetNumber = 4;
+          let maxMorphTargetNumber = Config.maxMorphTargetNumber;
           if (rnLoaderOptions?.maxMorphTargetNumber != null) {
             maxMorphTargetNumber = rnLoaderOptions.maxMorphTargetNumber;
           }

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -174,7 +174,8 @@ export default class ModelConverter {
       const rnBuffer = new Buffer({
         byteLength: buffer.byteLength,
         buffer: buffer.buffer!,
-        name: `gltf2Buffer_0_(${buffer.uri})`
+        name: `gltf2Buffer_0_(${buffer.uri})`,
+        byteAlign: 4
       });
       rnBuffers.push(rnBuffer);
     }
@@ -1623,7 +1624,8 @@ export default class ModelConverter {
     return new Buffer({
       byteLength: byteLengthOfBufferForDraco,
       buffer: new ArrayBuffer(byteLengthOfBufferForDraco),
-      name: 'Draco'
+      name: 'Draco',
+      byteAlign: 4
     });
   }
 }

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -1362,26 +1362,6 @@ export default class ModelConverter {
   }
 
   private __copyRnAccessorAndBufferView(srcRnAccessor: Accessor) {
-    // const byteSize = srcRnAccessor.elementCount * 4 /* vec4 */ * 4 /* bytes */;
-    // const dstRnBuffer = MemoryManager.getInstance().createOrGetBuffer(BufferUse.GPUVertexData);
-    // const dstRnBufferView = dstRnBuffer.takeBufferView({
-    //   byteLengthToNeed: byteSize,
-    //   byteStride: 4 /* vec4 */ * 4 /* bytes */,
-    //   isAoS: false
-    // });
-
-    // const dstRnAccessor = dstRnBufferView.takeAccessor({
-    //   compositionType: CompositionType.Vec4,
-    //   componentType: ComponentType.Float,
-    //   count: srcRnAccessor.elementCount,
-    //   max: srcRnAccessor.max,
-    //   min: srcRnAccessor.min,
-    //   normalized: srcRnAccessor.normalized
-    // });
-    // for (let i = 0; i < srcRnAccessor.elementCount; i++) {
-    //   dstRnAccessor.setElementFromAccessor(i, srcRnAccessor);
-    // }
-
     const byteSize = srcRnAccessor.elementCount * 3 /* vec4 */ * 4 /* bytes */;
     const dstRnBuffer = MemoryManager.getInstance().createOrGetBuffer(BufferUse.GPUVertexData);
     const dstRnBufferView = dstRnBuffer.takeBufferView({
@@ -1398,10 +1378,8 @@ export default class ModelConverter {
       min: srcRnAccessor.min,
       normalized: srcRnAccessor.normalized
     });
-    for (let i = 0; i < srcRnAccessor.elementCount; i++) {
-      dstRnAccessor.setElementFromAccessor(i, srcRnAccessor);
-    }
-    // dstRnAccessor.copyBuffer(srcRnAccessor);
+
+    dstRnAccessor.copyBuffer(srcRnAccessor);
 
     return dstRnAccessor;
   }

--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -308,7 +308,7 @@ export default class ModelConverter {
         //   //   }
         //   // }
         //   // skeletalComponent!.jointsHierarchy = rnEntities[node.skin.skeletonIndex].getSceneGraph();
-        // } else 
+        // } else
         if (node.mesh) {
           const joints = [];
           for (let i of node.skin.jointsIndices) {
@@ -543,8 +543,7 @@ export default class ModelConverter {
             for (let attributeName in target) {
               let attributeAccessor = target[attributeName] as Gltf2Accessor;
               const attributeRnAccessor = this.__getRnAccessor(attributeAccessor, rnBuffers[(attributeAccessor.bufferView as Gltf2BufferView).bufferIndex!]);
-              const attributeRnAccessorInGPUVertexData = this.__copyRnAccessorAndBufferView(attributeRnAccessor);
-              targetMap.set(VertexAttribute.fromString(attributeName), attributeRnAccessorInGPUVertexData);
+              targetMap.set(VertexAttribute.fromString(attributeName), attributeRnAccessor);
             }
             targets.push(targetMap);
           }

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -14,7 +14,7 @@ import BufferView from "../../memory/BufferView";
 import Accessor from "../../memory/Accessor";
 import ISingleShader from "../../../webgl/shaders/ISingleShader";
 import { ShaderType } from "../../definitions/ShaderType";
-import { Index, CGAPIResourceHandle, Count } from "../../../commontypes/CommonTypes";
+import { Index, CGAPIResourceHandle, Count, IndexOf16Bytes } from "../../../commontypes/CommonTypes";
 import DataUtil from "../../misc/DataUtil";
 import GlobalDataRepository from "../../core/GlobalDataRepository";
 import System from "../../system/System";
@@ -511,7 +511,7 @@ export default class Material extends RnObject {
     let vertexShaderBody = '';
     let pixelShaderBody = '';
     if (materialNode.vertexShaderityObject != null) {
-      vertexShaderBody = ShaderityUtility.getInstance().getVertexShaderBody(materialNode.vertexShaderityObject, { 
+      vertexShaderBody = ShaderityUtility.getInstance().getVertexShaderBody(materialNode.vertexShaderityObject, {
           getters: vertexPropertiesStr,
           definitions: definitions,
           dataUBODefinition: webglResourceRepository.getGlslDataUBODefinitionString(),
@@ -574,7 +574,7 @@ export default class Material extends RnObject {
 
   /**
    * @private
-   * @param propertySetter 
+   * @param propertySetter
    */
   _getProperties(propertySetter: getShaderPropertyFunc, isWebGL2: boolean) {
     let vertexPropertiesStr = '';
@@ -609,7 +609,7 @@ export default class Material extends RnObject {
     }
   }
 
-  static getLocationOffsetOfMemberOfMaterial(materialTypeName: string, propertyIndex: Index) {
+  static getLocationOffsetOfMemberOfMaterial(materialTypeName: string, propertyIndex: Index): IndexOf16Bytes {
     const material = Material.__instancesByTypes.get(materialTypeName)!;
     const info = material.__fieldsInfo.get(propertyIndex)!;
     if (info.soloDatum) {

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -169,7 +169,6 @@ export default class Material extends RnObject {
       bufferView = buffer.takeBufferView({
         byteLengthToNeed: totalByteLength,
         byteStride: 0,
-        byteAlign: 16,
         isAoS: false
       });
       this.__bufferViews.set(materialTypeName, bufferView);

--- a/src/foundation/memory/Accessor.test.ts
+++ b/src/foundation/memory/Accessor.test.ts
@@ -8,7 +8,9 @@ function createBuffer(byteSize: Byte) {
   const buffer = new Buffer({
     byteLength:arrayBuffer.byteLength,
     buffer: arrayBuffer,
-    name: 'TestBuffer'});
+    name: 'TestBuffer',
+    byteAlign: 4
+  });
 
   return buffer;
 }

--- a/src/foundation/memory/AccessorBase.ts
+++ b/src/foundation/memory/AccessorBase.ts
@@ -437,7 +437,7 @@ export default class AccessorBase extends RnObject {
   }
 
   copyBuffer(accessor: Accessor) {
-    (new Uint8Array(this.__raw)).set(new Uint8Array(accessor.__raw), this.__byteOffsetInRawArrayBufferOfBuffer);
+    (new Uint8Array(this.__raw)).set(new Uint8Array(accessor.__raw, accessor.__byteOffsetInRawArrayBufferOfBuffer), this.__byteOffsetInRawArrayBufferOfBuffer);
   }
 
   setElementFromAccessor(i: Index, accessor: Accessor, secondIdx?: Index) {

--- a/src/foundation/memory/AccessorBase.ts
+++ b/src/foundation/memory/AccessorBase.ts
@@ -436,6 +436,10 @@ export default class AccessorBase extends RnObject {
     }
   }
 
+  copyBuffer(accessor: Accessor) {
+    (new Uint8Array(this.__raw)).set(new Uint8Array(accessor.__raw), this.__byteOffsetInRawArrayBufferOfBuffer);
+  }
+
   setElementFromAccessor(i: Index, accessor: Accessor, secondIdx?: Index) {
     const j = (secondIdx != null) ? secondIdx : i
     if (this.compositionType.getNumberOfComponents() === 1) {

--- a/src/foundation/memory/Buffer.test.ts
+++ b/src/foundation/memory/Buffer.test.ts
@@ -8,7 +8,9 @@ function createBuffer(byteSize: Byte) {
   const buffer = new Buffer({
     byteLength:arrayBuffer.byteLength,
     buffer: arrayBuffer,
-    name: 'TestBuffer'});
+    name: 'TestBuffer',
+    byteAlign: 4
+  });
 
   return buffer;
 }

--- a/src/foundation/memory/Buffer.ts
+++ b/src/foundation/memory/Buffer.ts
@@ -9,11 +9,13 @@ export default class Buffer extends RnObject {
   private __name: string = '';
   private __takenBytesIndex: Byte = 0;
   private __bufferViews: Array<BufferView> = [];
+  private __byteAlign: Byte;
 
-  constructor({byteLength, buffer, name} : {byteLength: Byte, buffer: ArrayBuffer, name: string}) {
+  constructor({byteLength, buffer, name, byteAlign} : {byteLength: Byte, buffer: ArrayBuffer, name: string, byteAlign: Byte}) {
     super();
     this.__name = name;
     this.__byteLength = byteLength;
+    this.__byteAlign = byteAlign;
 
     if (buffer instanceof Uint8Array) {
       this.__raw = buffer.buffer
@@ -36,7 +38,8 @@ export default class Buffer extends RnObject {
     return this.__raw;
   }
 
-  takeBufferView({byteLengthToNeed, byteStride, isAoS, byteAlign = 4} : {byteLengthToNeed: Byte, byteStride: Byte, isAoS: boolean, byteAlign?: Byte}) {
+  takeBufferView({byteLengthToNeed, byteStride, isAoS} : {byteLengthToNeed: Byte, byteStride: Byte, isAoS: boolean}) {
+    const byteAlign = this.__byteAlign;
     if (byteLengthToNeed % byteAlign !== 0) {
       console.info(`Padding bytes added because byteLengthToNeed must be a multiple of ${byteAlign}.`);
       byteLengthToNeed += byteAlign - (byteLengthToNeed % byteAlign);
@@ -46,7 +49,7 @@ export default class Buffer extends RnObject {
     //   byteStride += 4 - (byteStride % 4);
     // }
 
-    const bufferView = new BufferView({buffer: this, byteOffset: this.__takenBytesIndex, byteLength: byteLengthToNeed, raw: this.__raw, isAoS: isAoS});
+    const bufferView = new BufferView({buffer: this, byteOffset: this.__takenBytesIndex, byteLength: byteLengthToNeed, raw: this.__raw, isAoS: isAoS, byteAlign});
     bufferView.byteStride = byteStride;
     this.__takenBytesIndex += Uint8Array.BYTES_PER_ELEMENT * byteLengthToNeed;
 
@@ -66,7 +69,8 @@ export default class Buffer extends RnObject {
     //   byteStride += 4 - (byteStride % 4);
     // }
 
-    const bufferView = new BufferView({buffer: this, byteOffset: byteOffset + this.__byteOffset, byteLength: byteLengthToNeed, raw: this.__raw, isAoS: isAoS});
+    const byteAlign = this.__byteAlign;
+    const bufferView = new BufferView({buffer: this, byteOffset: byteOffset + this.__byteOffset, byteLength: byteLengthToNeed, raw: this.__raw, isAoS: isAoS, byteAlign});
 
     const takenBytesIndex = Uint8Array.BYTES_PER_ELEMENT * byteLengthToNeed + byteOffset + this.__byteOffset;
     if (this.__takenBytesIndex < takenBytesIndex) {

--- a/src/foundation/memory/BufferView.test.ts
+++ b/src/foundation/memory/BufferView.test.ts
@@ -9,7 +9,9 @@ function createBuffer(byteSize: number) {
   const buffer = new Buffer({
     byteLength:arrayBuffer.byteLength,
     buffer: arrayBuffer,
-    name: 'TestBuffer'});
+    name: 'TestBuffer',
+    byteAlign: 4
+  });
 
   return buffer;
 }

--- a/src/foundation/memory/BufferView.ts
+++ b/src/foundation/memory/BufferView.ts
@@ -17,15 +17,17 @@ export default class BufferView extends RnObject {
   private __raw: ArrayBuffer;
   private __isAoS: boolean;
   private __accessors: Array<Accessor> = [];
+  private __byteAlign: Byte;
 
-  constructor({ buffer, byteOffset, byteLength, raw, isAoS }:
-    { buffer: Buffer, byteOffset: Byte, byteLength: Byte, raw: ArrayBuffer, isAoS: boolean }) {
+  constructor({ buffer, byteOffset, byteLength, raw, isAoS, byteAlign }:
+    { buffer: Buffer, byteOffset: Byte, byteLength: Byte, raw: ArrayBuffer, isAoS: boolean, byteAlign: Byte }) {
     super();
     this.__buffer = buffer;
     this.__byteOffsetInRawArrayBufferOfBuffer = byteOffset;
     this.__byteLength = byteLength;
     this.__raw = raw;
     this.__isAoS = isAoS;
+    this.__byteAlign = byteAlign;
   }
 
   set byteStride(stride: Byte) {
@@ -88,15 +90,15 @@ export default class BufferView extends RnObject {
     return new Uint8Array(this.__raw, this.__byteOffsetInRawArrayBufferOfBuffer, this.__byteLength);
   }
 
-  takeAccessor({ compositionType, componentType, count, max, min, byteAlign = 4, arrayLength, normalized = false }:
+  takeAccessor({ compositionType, componentType, count, max, min, arrayLength, normalized = false }:
     {
       compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, count: Count,
-      max?: number[], min?: number[], byteAlign?: Byte, arrayLength?: Size, normalized?: boolean
+      max?: number[], min?: number[], arrayLength?: Size, normalized?: boolean
     }): Accessor {
 
     const byteStride = this.byteStride;
     const _arrayLength = (arrayLength != null) ? arrayLength : 1;
-
+    const byteAlign = this.__byteAlign;
     const accessor = this.__takeAccessorInner({
       compositionType, componentType, count, byteStride, accessorClass: Accessor,
       max, min, byteAlign, arrayLength: _arrayLength, normalized
@@ -105,7 +107,7 @@ export default class BufferView extends RnObject {
     return accessor;
   }
 
-  takeFlexibleAccessor({ compositionType, componentType, count, byteStride, max, min, byteAlign = 4, arrayLength, normalized = false }:
+  takeFlexibleAccessor({ compositionType, componentType, count, byteStride, max, min, byteAlign = 16, arrayLength, normalized = false }:
     {
       compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum, count: Count,
       byteStride: Byte, max?: number[], min?: number[], byteAlign?: Byte, arrayLength?: Size, normalized?: boolean

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -77,29 +77,34 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
   vec3 get_position(float vertexId, vec3 basePosition) {
     vec3 position = basePosition;
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
-      int basePosIn16bytes = u_dataTextureMorphOffsetPosition[i];
-      #ifdef GLSL_ES3
-      int posIn4bytes = 3 * int(vertexId) % 4;
-      #else
-      int posIn4bytes = int(mod(3.0 * vertexId, 4.0));
-      #endif
+      // int scalar_idx = 3 * int(vertexId);
+      // #ifdef GLSL_ES3
+      //   int posIn4bytes = scalar_idx % 4;
+      // #else
+      //   int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+      // #endif
 
-      vec3 addPos = vec3(0.0);
-      if (posIn4bytes == 0) {
-        vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-        addPos = val.xyz;
-      } else if (posIn4bytes == 1) {
-        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-        addPos = vec3(val0.yzw);
-      } else if (posIn4bytes == 2) {
-        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
-        addPos = vec3(val0.zw, val1.x);
-      } else if (posIn4bytes == 3) {
-        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
-        addPos = vec3(val0.w, val1.xy);
-      }
+      // int basePosIn16bytes = u_dataTextureMorphOffsetPosition[i] + (scalar_idx - posIn4bytes)/4;
+
+      // vec3 addPos = vec3(0.0);
+      // if (posIn4bytes == 0) {
+      //   vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+      //   addPos = val.xyz;
+      // } else if (posIn4bytes == 1) {
+      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+      //   addPos = vec3(val0.yzw);
+      // } else if (posIn4bytes == 2) {
+      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+      //   vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+      //   addPos = vec3(val0.zw, val1.x);
+      // } else if (posIn4bytes == 3) {
+      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+      //   vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+      //   addPos = vec3(val0.w, val1.xy);
+      // }
+
+      int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
+      vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
 
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -77,8 +77,30 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
   vec3 get_position(float vertexId, vec3 basePosition) {
     vec3 position = basePosition;
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
-      int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
-      vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
+      int basePosIn16bytes = u_dataTextureMorphOffsetPosition[i];
+      #ifdef GLSL_ES3
+      int posIn4bytes = 3 * int(vertexId) % 4;
+      #else
+      int posIn4bytes = int(mod(3.0 * vertexId, 4.0));
+      #endif
+
+      vec3 addPos = vec3(0.0);
+      if (posIn4bytes == 0) {
+        vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        addPos = val.xyz;
+      } else if (posIn4bytes == 1) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.yzw);
+      } else if (posIn4bytes == 2) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.zw, val1.x);
+      } else if (posIn4bytes == 3) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.w, val1.xy);
+      }
+
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {
         break;

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -76,35 +76,35 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
 #ifdef RN_IS_MORPHING
   vec3 get_position(float vertexId, vec3 basePosition) {
     vec3 position = basePosition;
+    int scalar_idx = 3 * int(vertexId);
+    #ifdef GLSL_ES3
+      int posIn4bytes = scalar_idx % 4;
+    #else
+      int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+    #endif
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
-      // int scalar_idx = 3 * int(vertexId);
-      // #ifdef GLSL_ES3
-      //   int posIn4bytes = scalar_idx % 4;
-      // #else
-      //   int posIn4bytes = int(mod(float(scalar_idx), 4.0));
-      // #endif
 
-      // int basePosIn16bytes = u_dataTextureMorphOffsetPosition[i] + (scalar_idx - posIn4bytes)/4;
+      int basePosIn16bytes = u_dataTextureMorphOffsetPosition[i] + (scalar_idx - posIn4bytes)/4;
 
-      // vec3 addPos = vec3(0.0);
-      // if (posIn4bytes == 0) {
-      //   vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-      //   addPos = val.xyz;
-      // } else if (posIn4bytes == 1) {
-      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-      //   addPos = vec3(val0.yzw);
-      // } else if (posIn4bytes == 2) {
-      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-      //   vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
-      //   addPos = vec3(val0.zw, val1.x);
-      // } else if (posIn4bytes == 3) {
-      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-      //   vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
-      //   addPos = vec3(val0.w, val1.xy);
-      // }
+      vec3 addPos = vec3(0.0);
+      if (posIn4bytes == 0) {
+        vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        addPos = val.xyz;
+      } else if (posIn4bytes == 1) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.yzw);
+      } else if (posIn4bytes == 2) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.zw, val1.x);
+      } else if (posIn4bytes == 3) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.w, val1.xy);
+      }
 
-      int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
-      vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
+      // int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
+      // vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
 
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -24,7 +24,7 @@ import LightComponent from "../foundation/components/LightComponent";
 import Config from "../foundation/core/Config";
 import RenderPass from "../foundation/renderer/RenderPass";
 import CameraComponent from "../foundation/components/CameraComponent";
-import { WebGLResourceHandle, Index, CGAPIResourceHandle, Count, IndexOf16Bytes } from "../commontypes/CommonTypes";
+import { WebGLResourceHandle, Index, CGAPIResourceHandle, Count, IndexOf16Bytes, IndexOf4Bytes } from "../commontypes/CommonTypes";
 import GlobalDataRepository from "../foundation/core/GlobalDataRepository";
 import VectorN from "../foundation/math/VectorN";
 import { WellKnownComponentTIDs } from "../foundation/components/WellKnownComponentTIDs";
@@ -154,18 +154,24 @@ export default class WebGLStrategyFastest implements WebGLStrategy {
     (shaderProgram as any).currentComponentSIDs = gl.getUniformLocation(shaderProgram, 'u_currentComponentSIDs');
   }
 
-  private static __getOffsetOfShaderSemanticsInfo(info: ShaderSemanticsInfo) {
+  private static __getOffsetOfShaderSemanticsInfo(info: ShaderSemanticsInfo): IndexOf4Bytes {
     let offset = 1;
     switch (info.compositionType) {
       case CompositionType.Mat4:
       case CompositionType.Mat4Array:
-        offset = 4;
+        offset = 16;
         break;
       case CompositionType.Mat3:
-        offset = 3;
+      case CompositionType.Mat3Array:
+        offset = 9;
         break;
       case CompositionType.Mat2:
-        offset = 2;
+      case CompositionType.Mat2Array:
+        offset = 4;
+        break;
+      case CompositionType.Scalar:
+      case CompositionType.ScalarArray:
+        offset = 1;
         break;
       default:
       // console.error('unknown composition type', info.compositionType.str, memberName);

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -363,6 +363,10 @@ ${returnType} get_${methodName}(highp float _instanceId, const int idxOfArray) {
         str += `        mat3 val = fetchMat3(u_dataTexture, vec4_idx, widthOfDataTexture, heightOfDataTexture);\n`; break;
       case CompositionType.Mat3Array:
         str += `        mat3 val = fetchMat3No16BytesAligned(u_dataTexture, scalar_idx, widthOfDataTexture, heightOfDataTexture);\n`; break;
+      case CompositionType.Mat2:
+        str += `        mat2 val = fetchMat2(u_dataTexture, vec4_idx, widthOfDataTexture, heightOfDataTexture);\n`; break;
+      case CompositionType.Mat2Array:
+        str += `        mat2 val = fetchMat2No16BytesAligned(u_dataTexture, scalar_idx, widthOfDataTexture, heightOfDataTexture);\n`; break;
       default:
         // console.error('unknown composition type', info.compositionType.str, memberName);
         str += '';

--- a/src/webgl/WebGLStrategyUniform.ts
+++ b/src/webgl/WebGLStrategyUniform.ts
@@ -139,35 +139,35 @@ mat3 get_normalMatrix(float instanceId) {
 #ifdef RN_IS_MORPHING
   vec3 get_position(float vertexId, vec3 basePosition) {
     vec3 position = basePosition;
+    int scalar_idx = 3 * int(vertexId);
+    #ifdef GLSL_ES3
+      int posIn4bytes = scalar_idx % 4;
+    #else
+      int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+    #endif
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
-      // int scalar_idx = u_dataTextureMorphOffsetPosition[i]*4 + (3 * int(vertexId));
-      // #ifdef GLSL_ES3
-      //   int posIn4bytes = scalar_idx % 4;
-      // #else
-      //   int posIn4bytes = int(mod(float(scalar_idx), 4.0));
-      // #endif
 
-      // int basePosIn16bytes = scalar_idx*4 - posIn4bytes;
+      int basePosIn16bytes = u_dataTextureMorphOffsetPosition[i] + (scalar_idx - posIn4bytes)/4;
 
-      // vec3 addPos = vec3(0.0);
-      // if (posIn4bytes == 0) {
-      //   vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-      //   addPos = val.xyz;
-      // } else if (posIn4bytes == 1) {
-      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-      //   addPos = vec3(val0.yzw);
-      // } else if (posIn4bytes == 2) {
-      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-      //   vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
-      //   addPos = vec3(val0.zw, val1.x);
-      // } else if (posIn4bytes == 3) {
-      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-      //   vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
-      //   addPos = vec3(val0.w, val1.xy);
-      // }
+      vec3 addPos = vec3(0.0);
+      if (posIn4bytes == 0) {
+        vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        addPos = val.xyz;
+      } else if (posIn4bytes == 1) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.yzw);
+      } else if (posIn4bytes == 2) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.zw, val1.x);
+      } else if (posIn4bytes == 3) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.w, val1.xy);
+      }
 
-      int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
-      vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
+      // int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
+      // vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
 
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {

--- a/src/webgl/WebGLStrategyUniform.ts
+++ b/src/webgl/WebGLStrategyUniform.ts
@@ -140,8 +140,30 @@ mat3 get_normalMatrix(float instanceId) {
   vec3 get_position(float vertexId, vec3 basePosition) {
     vec3 position = basePosition;
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
-      int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
-      vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
+      int basePosIn16bytes = u_dataTextureMorphOffsetPosition[i];
+      #ifdef GLSL_ES3
+      int posIn4bytes = 3 * int(vertexId) % 4;
+      #else
+      int posIn4bytes = int(mod(3.0 * vertexId, 4.0));
+      #endif
+
+      vec3 addPos = vec3(0.0);
+      if (posIn4bytes == 0) {
+        vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        addPos = val.xyz;
+      } else if (posIn4bytes == 1) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.yzw);
+      } else if (posIn4bytes == 2) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.zw, val1.x);
+      } else if (posIn4bytes == 3) {
+        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+        addPos = vec3(val0.w, val1.xy);
+      }
+
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {
         break;

--- a/src/webgl/WebGLStrategyUniform.ts
+++ b/src/webgl/WebGLStrategyUniform.ts
@@ -140,29 +140,34 @@ mat3 get_normalMatrix(float instanceId) {
   vec3 get_position(float vertexId, vec3 basePosition) {
     vec3 position = basePosition;
     for (int i=0; i<${Config.maxVertexMorphNumberInShader}; i++) {
-      int basePosIn16bytes = u_dataTextureMorphOffsetPosition[i];
-      #ifdef GLSL_ES3
-      int posIn4bytes = 3 * int(vertexId) % 4;
-      #else
-      int posIn4bytes = int(mod(3.0 * vertexId, 4.0));
-      #endif
+      // int scalar_idx = u_dataTextureMorphOffsetPosition[i]*4 + (3 * int(vertexId));
+      // #ifdef GLSL_ES3
+      //   int posIn4bytes = scalar_idx % 4;
+      // #else
+      //   int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+      // #endif
 
-      vec3 addPos = vec3(0.0);
-      if (posIn4bytes == 0) {
-        vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-        addPos = val.xyz;
-      } else if (posIn4bytes == 1) {
-        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-        addPos = vec3(val0.yzw);
-      } else if (posIn4bytes == 2) {
-        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
-        addPos = vec3(val0.zw, val1.x);
-      } else if (posIn4bytes == 3) {
-        vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
-        vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
-        addPos = vec3(val0.w, val1.xy);
-      }
+      // int basePosIn16bytes = scalar_idx*4 - posIn4bytes;
+
+      // vec3 addPos = vec3(0.0);
+      // if (posIn4bytes == 0) {
+      //   vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+      //   addPos = val.xyz;
+      // } else if (posIn4bytes == 1) {
+      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+      //   addPos = vec3(val0.yzw);
+      // } else if (posIn4bytes == 2) {
+      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+      //   vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+      //   addPos = vec3(val0.zw, val1.x);
+      // } else if (posIn4bytes == 3) {
+      //   vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, widthOfDataTexture, heightOfDataTexture);
+      //   vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, widthOfDataTexture, heightOfDataTexture);
+      //   addPos = vec3(val0.w, val1.xy);
+      // }
+
+      int index = u_dataTextureMorphOffsetPosition[i] + 1 * int(vertexId);
+      vec3 addPos = fetchElement(u_dataTexture, index, widthOfDataTexture, heightOfDataTexture).xyz;
 
       position += addPos * u_morphWeights[i];
       if (i == u_morphTargetNumber-1) {

--- a/src/webgl/shaderity_shaders/common/prerequisites.glsl
+++ b/src/webgl/shaderity_shaders/common/prerequisites.glsl
@@ -35,11 +35,54 @@ highp vec4 fetchElement(highp sampler2D tex, int vec4_idx, int texWidth, int tex
 #endif
 }
 
+vec2 fetchVec2No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+#ifdef GLSL_ES3
+  int posIn4bytes = scalar_idx % 4;
+#else
+  int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+#endif
+
+  int basePosIn16bytes = scalar_idx*4 - posIn4bytes;
+  if (posIn4bytes == 0) {
+    vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    return val.xy;
+  } else if (posIn4bytes == 1) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    return vec2(val0.yz);
+  } else if (posIn4bytes == 2) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, texWidth, texHeight);
+    return vec2(val0.zw);
+  } else if (posIn4bytes == 3) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, texWidth, texHeight);
+    return vec2(val0.w, val1.x);
+  }
+}
+
 vec3 fetchVec3No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+#ifdef GLSL_ES3
+  int posIn4bytes = scalar_idx % 4;
+#else
+  int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+#endif
 
-  vec4 val = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
-
-  return val.xyz;
+  int basePosIn16bytes = scalar_idx*4 - posIn4bytes;
+  if (posIn4bytes == 0) {
+    vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    return val.xyz;
+  } else if (posIn4bytes == 1) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    return vec3(val0.yzw);
+  } else if (posIn4bytes == 2) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, texWidth, texHeight);
+    return vec3(val0.zw, val1.x);
+  } else if (posIn4bytes == 3) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, texWidth, texHeight);
+    return vec3(val0.w, val1.xy);
+  }
 }
 
 vec4 fetchVec4(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
@@ -52,7 +95,8 @@ float fetchScalarNo16BytesAligned(highp sampler2D tex, int scalar_idx, int texWi
 }
 
 mat2 fetchMat2No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+  int vec4_idx = scalar_idx*4;
+  vec4 col0 = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
 
   mat2 val = mat2(
     col0.x, col0.y,
@@ -74,17 +118,55 @@ mat2 fetchMat2(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
 }
 
 mat3 fetchMat3No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
-  vec4 col1 = fetchElement(u_dataTexture, scalar_idx + 1, texWidth, texHeight);
-  vec4 col2 = fetchElement(u_dataTexture, scalar_idx + 2, texWidth, texHeight);
+#ifdef GLSL_ES3
+  int posIn4bytes = scalar_idx % 4;
+#else
+  int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+#endif
 
-  mat3 val = mat3(
-    col0.x, col0.y, col0.z,
-    col0.w, col1.x, col1.y,
-    col1.z, col1.w, col2.x
-    );
+  int basePosIn16bytes = scalar_idx*4 - posIn4bytes;
+  if (posIn4bytes == 0) {
+    vec4 col0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 col1 = fetchElement(u_dataTexture, basePosIn16bytes + 1, texWidth, texHeight);
+    vec4 col2 = fetchElement(u_dataTexture, basePosIn16bytes + 2, texWidth, texHeight);
+    mat3 val = mat3(
+      col0.x, col0.y, col0.z,
+      col0.w, col1.x, col1.y,
+      col1.z, col1.w, col2.x
+      );
+    return val;
+  } else if (posIn4bytes == 1) {
+    vec4 col0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 col1 = fetchElement(u_dataTexture, basePosIn16bytes + 1, texWidth, texHeight);
+    vec4 col2 = fetchElement(u_dataTexture, basePosIn16bytes + 2, texWidth, texHeight);
+    mat3 val = mat3(
+      col0.y, col0.z, col0.w,
+      col1.x, col1.y, col1.z,
+      col1.w, col2.x, col2.y
+      );
+    return val;
+  } else if (posIn4bytes == 2) {
+    vec4 col0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 col1 = fetchElement(u_dataTexture, basePosIn16bytes + 1, texWidth, texHeight);
+    vec4 col2 = fetchElement(u_dataTexture, basePosIn16bytes + 2, texWidth, texHeight);
+    mat3 val = mat3(
+      col0.z, col0.w, col1.x,
+      col1.y, col1.z, col1.w,
+      col2.x, col2.y, col2.z
+      );
+    return val;
+  } else { // posIn4bytes == 3
+    vec4 col0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 col1 = fetchElement(u_dataTexture, basePosIn16bytes + 1, texWidth, texHeight);
+    vec4 col2 = fetchElement(u_dataTexture, basePosIn16bytes + 2, texWidth, texHeight);
+    mat3 val = mat3(
+      col0.w, col1.x, col1.y,
+      col1.z, col1.w, col2.x,
+      col2.y, col2.z, col2.w
+      );
+    return val;
+  }
 
-  return val;
 }
 
 mat3 fetchMat3(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {

--- a/src/webgl/shaderity_shaders/common/prerequisites.glsl
+++ b/src/webgl/shaderity_shaders/common/prerequisites.glsl
@@ -35,9 +35,29 @@ highp vec4 fetchElement(highp sampler2D tex, int vec4_idx, int texWidth, int tex
 #endif
 }
 
+vec3 fetchVec3No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+
+  vec4 val = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+
+  return val.xyz;
+}
 
 vec4 fetchVec4(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
-  vec4 val = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
+  return fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
+}
+
+float fetchScalarNo16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+  vec4 val = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+  return val.x;
+}
+
+mat2 fetchMat2No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+
+  mat2 val = mat2(
+    col0.x, col0.y,
+    col0.z, col0.w
+    );
 
   return val;
 }
@@ -48,6 +68,20 @@ mat2 fetchMat2(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
   mat2 val = mat2(
     col0.x, col0.y,
     col0.z, col0.w
+    );
+
+  return val;
+}
+
+mat3 fetchMat3No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+  vec4 col1 = fetchElement(u_dataTexture, scalar_idx + 1, texWidth, texHeight);
+  vec4 col2 = fetchElement(u_dataTexture, scalar_idx + 2, texWidth, texHeight);
+
+  mat3 val = mat3(
+    col0.x, col0.y, col0.z,
+    col0.w, col1.x, col1.y,
+    col1.z, col1.w, col2.x
     );
 
   return val;

--- a/src/webgl/shaderity_shaders/common/prerequisites.glsl
+++ b/src/webgl/shaderity_shaders/common/prerequisites.glsl
@@ -9,61 +9,54 @@ uniform sampler2D u_dataTexture; // skipProcess=true
 #endif
 
 
-  /*
-  * This idea from https://qiita.com/YVT/items/c695ab4b3cf7faa93885
-  * arg = vec2(1. / size.x, 1. / size.x / size.y);
-  */
-  // highp vec4 fetchElement(highp sampler2D tex, highp float index, highp vec2 arg)
-  // {
-  //   return ${this.glsl_texture}( tex, arg * (index + 0.5) );
-  // }
-
-highp vec4 fetchElement(highp sampler2D tex, int index, int texWidth, int texHeight) {
+highp vec4 fetchElement(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
 #if defined(GLSL_ES3) && defined(RN_IS_FASTEST_MODE)
-  if (index < dataUBOVec4Size) {
-    return fetchVec4FromVec4Block(index);
+  if (vec4_idx < dataUBOVec4Size) {
+    return fetchVec4FromVec4Block(vec4_idx);
   } else {
-    int idxOnDataTex = index - dataUBOVec4Size;
+    int idxOnDataTex = vec4_idx - dataUBOVec4Size;
     highp ivec2 uv = ivec2(idxOnDataTex % texWidth, idxOnDataTex / texWidth);
     return texelFetch( tex, uv, 0 );
   }
 #elif defined(GLSL_ES3)
-  highp ivec2 uv = ivec2(index % texWidth, index / texWidth);
+  highp ivec2 uv = ivec2(vec4_idx % texWidth, vec4_idx / texWidth);
   return texelFetch( tex, uv, 0 );
 #else
+  // This idea from https://qiita.com/YVT/items/c695ab4b3cf7faa93885
   highp vec2 invSize = vec2(1.0/float(texWidth), 1.0/float(texHeight));
-  highp float t = (float(index) + 0.5) * invSize.x;
+  highp float t = (float(vec4_idx) + 0.5) * invSize.x;
   highp float x = fract(t);
   highp float y = (floor(t) + 0.5) * invSize.y;
-#ifdef GLSL_ES3  
+  #ifdef GLSL_ES3
   return texture( tex, vec2(x, y));
-#else
+  #else
   return texture2D( tex, vec2(x, y));
-#endif
+  #endif
 #endif
 }
 
-vec4 fetchVec4(highp sampler2D tex, int idx, int texWidth, int texHeight) {
-  vec4 val = fetchElement(u_dataTexture, idx, texWidth, texHeight);
+
+vec4 fetchVec4(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
+  vec4 val = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
 
   return val;
 }
 
-mat2 fetchMat2(highp sampler2D tex, int idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
+mat2 fetchMat2(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
 
   mat2 val = mat2(
     col0.x, col0.y,
     col0.z, col0.w
     );
-  
+
   return val;
 }
 
-mat3 fetchMat3(highp sampler2D tex, int idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
-  vec4 col1 = fetchElement(u_dataTexture, idx + 1, texWidth, texHeight);
-  vec4 col2 = fetchElement(u_dataTexture, idx + 2, texWidth, texHeight);
+mat3 fetchMat3(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
+  vec4 col1 = fetchElement(u_dataTexture, vec4_idx + 1, texWidth, texHeight);
+  vec4 col2 = fetchElement(u_dataTexture, vec4_idx + 2, texWidth, texHeight);
 
   mat3 val = mat3(
     col0.x, col0.y, col0.z,
@@ -74,11 +67,11 @@ mat3 fetchMat3(highp sampler2D tex, int idx, int texWidth, int texHeight) {
   return val;
 }
 
-mat4 fetchMat4(highp sampler2D tex, int idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
-  vec4 col1 = fetchElement(u_dataTexture, idx + 1, texWidth, texHeight);
-  vec4 col2 = fetchElement(u_dataTexture, idx + 2, texWidth, texHeight);
-  vec4 col3 = fetchElement(u_dataTexture, idx + 3, texWidth, texHeight);
+mat4 fetchMat4(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
+  vec4 col1 = fetchElement(u_dataTexture, vec4_idx + 1, texWidth, texHeight);
+  vec4 col2 = fetchElement(u_dataTexture, vec4_idx + 2, texWidth, texHeight);
+  vec4 col3 = fetchElement(u_dataTexture, vec4_idx + 3, texWidth, texHeight);
 
   mat4 val = mat4(
     col0.x, col0.y, col0.z, col0.w,

--- a/src/webgl/shaders/GLSLShader.ts
+++ b/src/webgl/shaders/GLSLShader.ts
@@ -406,11 +406,54 @@ highp vec4 fetchElement(highp sampler2D tex, int vec4_idx, int texWidth, int tex
 #endif
 }
 
+vec2 fetchVec2No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+#ifdef GLSL_ES3
+  int posIn4bytes = scalar_idx % 4;
+#else
+  int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+#endif
+
+  int basePosIn16bytes = scalar_idx*4 - posIn4bytes;
+  if (posIn4bytes == 0) {
+    vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    return val.xy;
+  } else if (posIn4bytes == 1) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    return vec2(val0.yz);
+  } else if (posIn4bytes == 2) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, texWidth, texHeight);
+    return vec2(val0.zw);
+  } else if (posIn4bytes == 3) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, texWidth, texHeight);
+    return vec2(val0.w, val1.x);
+  }
+}
+
 vec3 fetchVec3No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+#ifdef GLSL_ES3
+  int posIn4bytes = scalar_idx % 4;
+#else
+  int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+#endif
 
-  vec4 val = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
-
-  return val.xyz;
+  int basePosIn16bytes = scalar_idx*4 - posIn4bytes;
+  if (posIn4bytes == 0) {
+    vec4 val = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    return val.xyz;
+  } else if (posIn4bytes == 1) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    return vec3(val0.yzw);
+  } else if (posIn4bytes == 2) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, texWidth, texHeight);
+    return vec3(val0.zw, val1.x);
+  } else if (posIn4bytes == 3) {
+    vec4 val0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 val1 = fetchElement(u_dataTexture, basePosIn16bytes+1, texWidth, texHeight);
+    return vec3(val0.w, val1.xy);
+  }
 }
 
 vec4 fetchVec4(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
@@ -423,7 +466,8 @@ float fetchScalarNo16BytesAligned(highp sampler2D tex, int scalar_idx, int texWi
 }
 
 mat2 fetchMat2No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+  int vec4_idx = scalar_idx*4;
+  vec4 col0 = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
 
   mat2 val = mat2(
     col0.x, col0.y,
@@ -445,17 +489,55 @@ mat2 fetchMat2(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
 }
 
 mat3 fetchMat3No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
-  vec4 col1 = fetchElement(u_dataTexture, scalar_idx + 1, texWidth, texHeight);
-  vec4 col2 = fetchElement(u_dataTexture, scalar_idx + 2, texWidth, texHeight);
+#ifdef GLSL_ES3
+  int posIn4bytes = scalar_idx % 4;
+#else
+  int posIn4bytes = int(mod(float(scalar_idx), 4.0));
+#endif
 
-  mat3 val = mat3(
-    col0.x, col0.y, col0.z,
-    col0.w, col1.x, col1.y,
-    col1.z, col1.w, col2.x
-    );
+  int basePosIn16bytes = scalar_idx*4 - posIn4bytes;
+  if (posIn4bytes == 0) {
+    vec4 col0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 col1 = fetchElement(u_dataTexture, basePosIn16bytes + 1, texWidth, texHeight);
+    vec4 col2 = fetchElement(u_dataTexture, basePosIn16bytes + 2, texWidth, texHeight);
+    mat3 val = mat3(
+      col0.x, col0.y, col0.z,
+      col0.w, col1.x, col1.y,
+      col1.z, col1.w, col2.x
+      );
+    return val;
+  } else if (posIn4bytes == 1) {
+    vec4 col0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 col1 = fetchElement(u_dataTexture, basePosIn16bytes + 1, texWidth, texHeight);
+    vec4 col2 = fetchElement(u_dataTexture, basePosIn16bytes + 2, texWidth, texHeight);
+    mat3 val = mat3(
+      col0.y, col0.z, col0.w,
+      col1.x, col1.y, col1.z,
+      col1.w, col2.x, col2.y
+      );
+    return val;
+  } else if (posIn4bytes == 2) {
+    vec4 col0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 col1 = fetchElement(u_dataTexture, basePosIn16bytes + 1, texWidth, texHeight);
+    vec4 col2 = fetchElement(u_dataTexture, basePosIn16bytes + 2, texWidth, texHeight);
+    mat3 val = mat3(
+      col0.z, col0.w, col1.x,
+      col1.y, col1.z, col1.w,
+      col2.x, col2.y, col2.z
+      );
+    return val;
+  } else { // posIn4bytes == 3
+    vec4 col0 = fetchElement(u_dataTexture, basePosIn16bytes, texWidth, texHeight);
+    vec4 col1 = fetchElement(u_dataTexture, basePosIn16bytes + 1, texWidth, texHeight);
+    vec4 col2 = fetchElement(u_dataTexture, basePosIn16bytes + 2, texWidth, texHeight);
+    mat3 val = mat3(
+      col0.w, col1.x, col1.y,
+      col1.z, col1.w, col2.x,
+      col2.y, col2.z, col2.w
+      );
+    return val;
+  }
 
-  return val;
 }
 
 mat3 fetchMat3(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {

--- a/src/webgl/shaders/GLSLShader.ts
+++ b/src/webgl/shaders/GLSLShader.ts
@@ -380,61 +380,74 @@ const int heightOfDataTexture = ${MemoryManager.bufferHeightLength};
   ${dataUboDefinition}
 #endif
 
-  /*
-  * This idea from https://qiita.com/YVT/items/c695ab4b3cf7faa93885
-  * arg = vec2(1. / size.x, 1. / size.x / size.y);
-  */
-  // highp vec4 fetchElement(highp sampler2D tex, highp float index, highp vec2 arg)
-  // {
-  //   return ${this.glsl_texture}( tex, arg * (index + 0.5) );
-  // }
-
-highp vec4 fetchElement(highp sampler2D tex, int index, int texWidth, int texHeight) {
+highp vec4 fetchElement(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
 #if defined(GLSL_ES3) && defined(RN_IS_FASTEST_MODE)
-  if (index < dataUBOVec4Size) {
-    return fetchVec4FromVec4Block(index);
+  if (vec4_idx < dataUBOVec4Size) {
+    return fetchVec4FromVec4Block(vec4_idx);
   } else {
-    int idxOnDataTex = index - dataUBOVec4Size;
+    int idxOnDataTex = vec4_idx - dataUBOVec4Size;
     highp ivec2 uv = ivec2(idxOnDataTex % texWidth, idxOnDataTex / texWidth);
     return texelFetch( tex, uv, 0 );
   }
 #elif defined(GLSL_ES3)
-  highp ivec2 uv = ivec2(index % texWidth, index / texWidth);
+  highp ivec2 uv = ivec2(vec4_idx % texWidth, vec4_idx / texWidth);
   return texelFetch( tex, uv, 0 );
 #else
+  // This idea from https://qiita.com/YVT/items/c695ab4b3cf7faa93885
   highp vec2 invSize = vec2(1.0/float(texWidth), 1.0/float(texHeight));
-  highp float t = (float(index) + 0.5) * invSize.x;
+  highp float t = (float(vec4_idx) + 0.5) * invSize.x;
   highp float x = fract(t);
   highp float y = (floor(t) + 0.5) * invSize.y;
-#ifdef GLSL_ES3  
+  #ifdef GLSL_ES3
   return texture( tex, vec2(x, y));
-#else
+  #else
   return texture2D( tex, vec2(x, y));
-#endif
+  #endif
 #endif
 }
 
-vec4 fetchVec4(highp sampler2D tex, int idx, int texWidth, int texHeight) {
-  vec4 val = fetchElement(u_dataTexture, idx, texWidth, texHeight);
+vec3 fetchVec3No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
 
-  return val;
+  vec4 val = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+
+  return val.xyz;
 }
 
-mat2 fetchMat2(highp sampler2D tex, int idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
+vec4 fetchVec4(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
+  return fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
+}
+
+float fetchScalarNo16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+  vec4 val = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+  return val.x;
+}
+
+mat2 fetchMat2No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
 
   mat2 val = mat2(
     col0.x, col0.y,
     col0.z, col0.w
     );
-  
+
   return val;
 }
 
-mat3 fetchMat3(highp sampler2D tex, int idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
-  vec4 col1 = fetchElement(u_dataTexture, idx + 1, texWidth, texHeight);
-  vec4 col2 = fetchElement(u_dataTexture, idx + 2, texWidth, texHeight);
+mat2 fetchMat2(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
+
+  mat2 val = mat2(
+    col0.x, col0.y,
+    col0.z, col0.w
+    );
+
+  return val;
+}
+
+mat3 fetchMat3No16BytesAligned(highp sampler2D tex, int scalar_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, scalar_idx, texWidth, texHeight);
+  vec4 col1 = fetchElement(u_dataTexture, scalar_idx + 1, texWidth, texHeight);
+  vec4 col2 = fetchElement(u_dataTexture, scalar_idx + 2, texWidth, texHeight);
 
   mat3 val = mat3(
     col0.x, col0.y, col0.z,
@@ -445,11 +458,25 @@ mat3 fetchMat3(highp sampler2D tex, int idx, int texWidth, int texHeight) {
   return val;
 }
 
-mat4 fetchMat4(highp sampler2D tex, int idx, int texWidth, int texHeight) {
-  vec4 col0 = fetchElement(u_dataTexture, idx, texWidth, texHeight);
-  vec4 col1 = fetchElement(u_dataTexture, idx + 1, texWidth, texHeight);
-  vec4 col2 = fetchElement(u_dataTexture, idx + 2, texWidth, texHeight);
-  vec4 col3 = fetchElement(u_dataTexture, idx + 3, texWidth, texHeight);
+mat3 fetchMat3(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
+  vec4 col1 = fetchElement(u_dataTexture, vec4_idx + 1, texWidth, texHeight);
+  vec4 col2 = fetchElement(u_dataTexture, vec4_idx + 2, texWidth, texHeight);
+
+  mat3 val = mat3(
+    col0.x, col0.y, col0.z,
+    col0.w, col1.x, col1.y,
+    col1.z, col1.w, col2.x
+    );
+
+  return val;
+}
+
+mat4 fetchMat4(highp sampler2D tex, int vec4_idx, int texWidth, int texHeight) {
+  vec4 col0 = fetchElement(u_dataTexture, vec4_idx, texWidth, texHeight);
+  vec4 col1 = fetchElement(u_dataTexture, vec4_idx + 1, texWidth, texHeight);
+  vec4 col2 = fetchElement(u_dataTexture, vec4_idx + 2, texWidth, texHeight);
+  vec4 col3 = fetchElement(u_dataTexture, vec4_idx + 3, texWidth, texHeight);
 
   mat4 val = mat4(
     col0.x, col0.y, col0.z, col0.w,


### PR DESCRIPTION
This PR includes the following points:

- Add shader parameter getter like `fetchVec3No16BytesAligned`, which is not 16bytes aligned for byte offset calculation.
- Support CompositionType.*Array like CompositionType.Mat3Array truely.
- Remove vec3 -> vec4 data copy of VRM/glTF morph targets data because of supporting `fetch*No16BytesAligned` at this time, which is not 16bytes aligned for byte offset calculation.