### PR TITLE
Loading speed optimizations

### DIFF
--- a/src/foundation/definitions/CompositionType.ts
+++ b/src/foundation/definitions/CompositionType.ts
@@ -148,11 +148,19 @@ function isArray(compositionType: CompositionTypeEnum) {
   }
 }
 
+function isTexture(compositionType: CompositionTypeEnum) {
+  if (compositionType === Texture2D || compositionType === TextureCube) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 export const CompositionType = Object.freeze({
   Unknown, Scalar, Vec2, Vec3, Vec4,
   Mat2, Mat3, Mat4,
   ScalarArray, Vec2Array, Vec3Array, Vec4Array,
   Mat2Array, Mat3Array, Mat4Array,
   Texture2D, TextureCube,
-  from, fromString, fromGlslString, isArray
+  from, fromString, fromGlslString, isArray, isTexture
 });

--- a/src/foundation/definitions/ProcessApproach.ts
+++ b/src/foundation/definitions/ProcessApproach.ts
@@ -26,4 +26,45 @@ function from(index: number): ProcessApproachEnum|undefined {
   return _from({ typeList, index });
 }
 
-export const ProcessApproach = Object.freeze({ None, UniformWebGL1, UniformWebGL2, DataTextureWebGL1, DataTextureWebGL2, UBOWebGL2, TransformFeedbackWebGL2, FastestWebGL1, FastestWebGL2 });
+const isFastestApproach = (processApproach: ProcessApproachEnum) => {
+  switch (processApproach) {
+    case FastestWebGL1:
+    case FastestWebGL2:
+      return true;
+    default: return false;
+  }
+}
+
+const isUniformApproach = (processApproach: ProcessApproachEnum) => {
+  switch (processApproach) {
+    case UniformWebGL1:
+    case UniformWebGL2:
+      return true;
+    default: return false;
+  }
+}
+
+
+const isWebGL2Approach = (processApproach: ProcessApproachEnum) => {
+  switch (processApproach) {
+    case UniformWebGL2:
+    case FastestWebGL2:
+      return true;
+    default: return false;
+  }
+}
+
+
+export const ProcessApproach = Object.freeze({
+  isFastestApproach,
+  isUniformApproach,
+  None,
+  UniformWebGL1,
+  UniformWebGL2,
+  DataTextureWebGL1,
+  DataTextureWebGL2,
+  UBOWebGL2,
+  TransformFeedbackWebGL2,
+  FastestWebGL1,
+  FastestWebGL2,
+});

--- a/src/foundation/materials/core/AbstractMaterialNode.ts
+++ b/src/foundation/materials/core/AbstractMaterialNode.ts
@@ -406,9 +406,8 @@ export default abstract class AbstractMaterialNode extends RnObject {
       const accessor = target.get(VertexAttribute.Position) as Accessor;
       let offset = 0;
       let offset2 = 0;
-      if (SystemState.currentProcessApproach === ProcessApproach.FastestWebGL1 ||
-        SystemState.currentProcessApproach === ProcessApproach.FastestWebGL2
-        ) {
+
+      if (ProcessApproach.isFastestApproach(SystemState.currentProcessApproach)) {
         offset = Config.totalSizeOfGPUShaderDataStorageExceptMorphData;
         offset2 = memoryManager.createOrGetBuffer(BufferUse.GPUInstanceData).takenSizeInByte;
       }

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -469,9 +469,7 @@ export default class Material extends RnObject {
       definitions += '#version 300 es\n#define GLSL_ES3\n';
     }
     definitions += `#define RN_MATERIAL_TYPE_NAME ${this.__materialTypeName}\n`;
-    if (System.getInstance().processApproach === ProcessApproach.FastestWebGL1 ||
-      System.getInstance().processApproach === ProcessApproach.FastestWebGL2
-    ) {
+    if (ProcessApproach.isFastestApproach(System.getInstance().processApproach)) {
       definitions += '#define RN_IS_FASTEST_MODE\n';
     }
     if (glw.webgl1ExtSTL) {

--- a/src/foundation/misc/MiscUtil.ts
+++ b/src/foundation/misc/MiscUtil.ts
@@ -121,19 +121,18 @@ const concatArrayBuffers = function (segments: ArrayBuffer[], sizes: Byte[], off
   return whole.buffer;
 }
 
+const concatArrayBuffers2 = ({finalSize, srcs, srcsOffset, srcsCopySize}:
+  {finalSize: Byte, srcs: ArrayBuffer[], srcsOffset: Byte[], srcsCopySize: Byte[]}) =>
+{
+  const dstBuf = new Uint8Array(new ArrayBuffer(finalSize));
+  let copiedSize = 0;
+  for (let i in srcs) {
+    const src = srcs[i];
+    const srcBuf = new Uint8Array(src, srcsOffset[i], srcsCopySize[i]);
+    dstBuf.set(srcBuf, copiedSize);
+    copiedSize += srcsCopySize[i];
+  }
+  return dstBuf.buffer;
+}
 
-// const concatArrayBuffers = function (segments: ArrayBuffer[], sizes: Byte[], offsets: Byte[], paddingSize: Byte) {
-//   var sumLength = 0;
-//   for (var i = 0; i < sizes.length; ++i) {
-//     sumLength += sizes[i];
-//   }
-//   var whole = new Uint8Array(sumLength + paddingSize);
-//   var pos = 0;
-//   for (var i = 0; i < segments.length; ++i) {
-//     whole.set(new Uint8Array(segments[i+offsets[i]], 0, sizes[i]), pos);
-//     pos += sizes[i];
-//   }
-//   return whole.buffer;
-// }
-
-export const MiscUtil = Object.freeze({ isMobile, isIOS, preventDefaultForDesktopOnly, isObject, fillTemplate, isNode, concatArrayBuffers });
+export const MiscUtil = Object.freeze({ isMobile, isIOS, preventDefaultForDesktopOnly, isObject, fillTemplate, isNode, concatArrayBuffers, concatArrayBuffers2 });

--- a/src/foundation/textures/Texture.ts
+++ b/src/foundation/textures/Texture.ts
@@ -246,6 +246,8 @@ export default class Texture extends AbstractTexture {
     var canvas = document.createElement("canvas");
     canvas.width = 1;
     canvas.height = 1;
+    this.__width = 1;
+    this.__height = 1;
     const ctx = canvas.getContext('2d')!;
     ctx.fillStyle = rgbaStr;
     ctx.fillRect(0, 0, 1, 1);

--- a/src/webgl/WebGLContextWrapper.ts
+++ b/src/webgl/WebGLContextWrapper.ts
@@ -288,19 +288,16 @@ export default class WebGLContextWrapper {
   }
 
   unbindTexture2D(activeTextureIndex: Index) {
-    if (this.__isDebugMode) {
-      delete this.__activeTextures2D[activeTextureIndex];
-    }
     this.__activeTexture(activeTextureIndex);
     this.__gl.bindTexture(this.__gl.TEXTURE_2D, null);
+    delete this.__activeTextures2D[activeTextureIndex];
   }
 
   unbindTextureCube(activeTextureIndex: Index) {
-    if (this.__isDebugMode) {
-      delete this.__activeTexturesCube[activeTextureIndex];
-    }
+
     this.__activeTexture(activeTextureIndex);
     this.__gl.bindTexture(this.__gl.TEXTURE_CUBE_MAP, null);
+    delete this.__activeTexturesCube[activeTextureIndex];
   }
 
   unbindTextures() {

--- a/src/webgl/WebGLResourceRepository.ts
+++ b/src/webgl/WebGLResourceRepository.ts
@@ -26,6 +26,8 @@ import RenderBuffer from "../foundation/textures/RenderBuffer";
 import { BasisFile } from "../commontypes/BasisTexture";
 import { BasisCompressionTypeEnum, BasisCompressionType } from "../foundation/definitions/BasisCompressionType";
 import { WebGLExtension } from "./WebGLExtension";
+import { ProcessApproach } from "../foundation/definitions/ProcessApproach";
+import System from "../foundation/system/System";
 
 
 declare var HDRImage: any;
@@ -329,44 +331,51 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     }
   }
 
-  setupUniformLocations(shaderProgramUid: WebGLResourceHandle, dataArray: ShaderSemanticsInfo[]): WebGLProgram {
-    const gl = this.__glw!.getRawContext();
+  setupUniformLocations(shaderProgramUid: WebGLResourceHandle, infoArray: ShaderSemanticsInfo[]): WebGLProgram {
+    const glw = this.__glw!;
+    const gl = glw.getRawContext();
     const shaderProgram = this.getWebGLResource(shaderProgramUid) as any;
 
     const shaderSemanticsInfoMap: Map<string, ShaderSemanticsInfo> = new Map();
-    for (let arg of dataArray) {
-      shaderSemanticsInfoMap.set(arg.semantic.str, arg);
+    for (let info of infoArray) {
+      shaderSemanticsInfoMap.set(info.semantic.str, info);
     }
 
-    for (let data of dataArray) {
-      let semanticSingular = data.semantic.str;
+    for (let info of infoArray) {
+      let semanticSingular = info.semantic.str;
 
       let identifier = semanticSingular;
 
-      let shaderVarName = ShaderSemantics.fullSemanticStr(data);
-      if (data.index != null) {
+      let shaderVarName = ShaderSemantics.fullSemanticStr(info);
+      if (info.index != null) {
         if (shaderVarName.match(/\[.+?\]/)) {
-          shaderVarName = shaderVarName.replace(/\[.+?\]/g, `[${data.index}]`);
+          shaderVarName = shaderVarName.replace(/\[.+?\]/g, `[${info.index}]`);
         } else {
-          shaderVarName += `[${data.index}]`;
+          shaderVarName += `[${info.index}]`;
         }
       }
 
-      if (data.none_u_prefix !== true) {
+      if (info.none_u_prefix !== true) {
         shaderVarName = 'u_' + shaderVarName;
       }
-      const location = gl.getUniformLocation(shaderProgram, shaderVarName);
 
+      const isUniformExist = CompositionType.isTexture(info.compositionType) || info.needUniformInFastest || ProcessApproach.isUniformApproach(System.getInstance().processApproach);
 
-      if (data.index != null) {
-        if (shaderProgram[identifier] == null) {
-          shaderProgram[identifier] = [];
+      if (isUniformExist) {
+        const location = gl.getUniformLocation(shaderProgram, shaderVarName);
+
+        if (info.index != null) {
+          if (shaderProgram[identifier] == null) {
+            shaderProgram[identifier] = [];
+          }
+          shaderProgram[identifier][info.index] = location;
+        } else {
+          shaderProgram[identifier] = location;
         }
-        shaderProgram[identifier][data.index] = location;
-      } else {
-        shaderProgram[identifier] = location;
+        if (location == null && glw.isDebugMode) {
+          console.warn(`Rn: Can not get the uniform location: ${shaderVarName}}`);
+        }
       }
-
     }
 
     if (shaderProgram._shaderSemanticsInfoMap != null) {
@@ -495,73 +504,77 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     isVector: boolean, { x, y, z, w }: { x: number | TypedArray | Array<number> | Array<boolean> | boolean, y?: number | boolean, z?: number | boolean, w?: number | boolean }, { firstTime = true, delta }: { firstTime?: boolean, delta?: number }, index?: Count) {
 
     let identifier = semanticStr;
-    let program;
+    let loc: WebGLUniformLocation;
     if (index != null) {
-      program = (shaderProgram as any)[identifier][index];
+      loc = (shaderProgram as any)[identifier][index];
     } else {
-      program = (shaderProgram as any)[identifier];
+      loc = (shaderProgram as any)[identifier];
     }
+    if (loc == null) {
+      return false;
+    }
+    const uLocation: WebGLUniformLocation = loc;
 
     const gl = this.__glw!.getRawContext();
 
     if (isMatrix) {
       if (componentNumber === 4) {
-        gl.uniformMatrix4fv(program, false, x);
+        gl.uniformMatrix4fv(uLocation, false, x);
       } else {
-        gl.uniformMatrix3fv(program, false, x);
+        gl.uniformMatrix3fv(uLocation, false, x);
       }
     } else if (isVector) {
       const componentType = info.componentType === ComponentType.Int || info.componentType === ComponentType.Short || info.componentType === ComponentType.Byte;
       if (componentNumber === 1) {
         if (componentType) {
-          gl.uniform1iv(program, x);
+          gl.uniform1iv(uLocation, x);
         } else {
-          gl.uniform1fv(program, x);
+          gl.uniform1fv(uLocation, x);
         }
       } else if (componentNumber === 2) {
         if (componentType) {
-          gl.uniform2iv(program, x);
+          gl.uniform2iv(uLocation, x);
         } else {
-          gl.uniform2fv(program, x);
+          gl.uniform2fv(uLocation, x);
         }
       } else if (componentNumber === 3) {
         if (componentType) {
-          gl.uniform3iv(program, x);
+          gl.uniform3iv(uLocation, x);
         } else {
-          gl.uniform3fv(program, x);
+          gl.uniform3fv(uLocation, x);
         }
       } else if (componentNumber === 4) {
         if (componentType) {
-          gl.uniform4iv(program, x);
+          gl.uniform4iv(uLocation, x);
         } else {
-          gl.uniform4fv(program, x);
+          gl.uniform4fv(uLocation, x);
         }
       }
     } else {
       const componentType = info.componentType === ComponentType.Int || info.componentType === ComponentType.Short || info.componentType === ComponentType.Byte;
       if (componentNumber === 1) {
         if (componentType) {
-          gl.uniform1i(program, x);
+          gl.uniform1i(uLocation, x);
         } else {
-          gl.uniform1f(program, x);
+          gl.uniform1f(uLocation, x);
         }
       } else if (componentNumber === 2) {
         if (componentType) {
-          gl.uniform2i(program, x, y);
+          gl.uniform2i(uLocation, x, y);
         } else {
-          gl.uniform2f(program, x, y);
+          gl.uniform2f(uLocation, x, y);
         }
       } else if (componentNumber === 3) {
         if (componentType) {
-          gl.uniform3i(program, x, y, z);
+          gl.uniform3i(uLocation, x, y, z);
         } else {
-          gl.uniform3f(program, x, y, z);
+          gl.uniform3f(uLocation, x, y, z);
         }
       } else if (componentNumber === 4) {
         if (componentType) {
-          gl.uniform4i(program, x, y, z, w);
+          gl.uniform4i(uLocation, x, y, z, w);
         } else {
-          gl.uniform4f(program, x, y, z, w);
+          gl.uniform4f(uLocation, x, y, z, w);
         }
       }
     }

--- a/src/webgl/WebGLResourceRepository.ts
+++ b/src/webgl/WebGLResourceRepository.ts
@@ -244,18 +244,19 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     if (gl == null) {
       throw new Error("No WebGLRenderingContext set as Default.");
     }
+    const isDebugMode = this.__glw!.isDebugMode;
 
     const vertexShader = gl.createShader(gl.VERTEX_SHADER)!;
     gl.shaderSource(vertexShader, vertexShaderStr);
     gl.compileShader(vertexShader);
-    if (this.__glw!.isDebugMode) {
+    if (isDebugMode) {
       this.__checkShaderCompileStatus(materialTypeName, vertexShader, vertexShaderStr);
     }
 
     const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER)!;
     gl.shaderSource(fragmentShader, fragmentShaderStr);
     gl.compileShader(fragmentShader);
-    if (this.__glw!.isDebugMode) {
+    if (isDebugMode) {
       this.__checkShaderCompileStatus(materialTypeName, fragmentShader, fragmentShaderStr);
     }
 
@@ -272,7 +273,7 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     });
 
     gl.linkProgram(shaderProgram);
-    if (this.__glw!.isDebugMode) {
+    if (isDebugMode) {
       this.__checkShaderProgramLinkStatus(materialTypeName, shaderProgram, vertexShaderStr, fragmentShaderStr);
     }
 
@@ -306,7 +307,7 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     const glw = this.__glw!;
     const gl = glw!.getRawContext();
 
-    if (glw.isDebugMode && !gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
       console.log('MaterialTypeName: ' + materialTypeName);
       console.log(this.__addLineNumber(shaderText));
       throw new Error('An error occurred compiling the shaders:' + gl.getShaderInfoLog(shader));
@@ -318,7 +319,7 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     const gl = glw!.getRawContext();
 
     // If creating the shader program failed, alert
-    if (glw.isDebugMode && !gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
+    if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
       console.log('MaterialTypeName: ' + materialTypeName);
       console.log(this.__addLineNumber('Vertex Shader:'));
       console.log(this.__addLineNumber(vertexShaderText));
@@ -1253,7 +1254,7 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     const isWebGL2 = this.__glw!.isWebGL2;
 
     this.__glw!.bindTexture2D(0, texture);
-    
+
     if (isWebGL2 || ArrayBuffer.isView(textureData)) {
       gl.texSubImage2D(gl.TEXTURE_2D, level, 0, 0, width, height, format.index, type.index, textureData);
     } else {
@@ -1417,7 +1418,7 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     for (let i=0; i<maxConventionblocks; i++) {
       gl.bindBufferRange(gl.UNIFORM_BUFFER, i, ubo, alignedMaxUniformBlockSize * i, alignedMaxUniformBlockSize);
     }
-    
+
     return resourceHandle;
   }
 
@@ -1430,7 +1431,7 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
 layout (std140) uniform Vec4Block${i} {
   vec4 vec4Block${i}[${alignedMaxUniformBlockSize/4/4}];
 };
-`    
+`
     }
 
     text += `
@@ -1446,7 +1447,7 @@ vec4 fetchVec4FromVec4Block(int vec4Idx) {
 }`;
     }
     text += '}\n';
-    
+
     return text;
   }
 

--- a/src/webgl/WebGLStrategyFastest.ts
+++ b/src/webgl/WebGLStrategyFastest.ts
@@ -515,11 +515,12 @@ ${returnType} get_${methodName}(highp float _instanceId, const int idxOfArray) {
         const actualSpaceForDataTextureInByte = buffer.takenSizeInByte - startOffsetOfDataTextureOnGPUInstanceData;
         const spareSpaceTexel = MemoryManager.bufferWidthLength - (actualSpaceForDataTextureInByte / 4 / 4) % MemoryManager.bufferWidthLength;
         const spareSpaceBytes = spareSpaceTexel * 4 * 4;
-        const finalArrayBuffer = MiscUtil.concatArrayBuffers(
-          [buffer.getArrayBuffer(), morphBufferArrayBuffer],
-          [actualSpaceForDataTextureInByte + spareSpaceBytes, morphBufferTakenSizeInByte],
-          [startOffsetOfDataTextureOnGPUInstanceData, 0],
-          dataTextureByteSize);
+        const finalArrayBuffer = MiscUtil.concatArrayBuffers2({
+          finalSize: dataTextureByteSize,
+          srcs: [buffer.getArrayBuffer(), morphBufferArrayBuffer],
+          srcsCopySize: [actualSpaceForDataTextureInByte + spareSpaceBytes, morphBufferTakenSizeInByte],
+          srcsOffset: [startOffsetOfDataTextureOnGPUInstanceData, 0]
+        });
         // if (finalArrayBuffer.byteLength / MemoryManager.bufferWidthLength / 4 / 4 > MemoryManager.bufferHeightLength) {
         if (actualSpaceForDataTextureInByte + spareSpaceBytes + morphBufferTakenSizeInByte > dataTextureByteSize) {
           console.warn('The buffer size exceeds the size of the data texture.');

--- a/src/webgl/WebGLStrategyUniform.ts
+++ b/src/webgl/WebGLStrategyUniform.ts
@@ -278,11 +278,12 @@ mat3 get_normalMatrix(float instanceId) {
         console.warn('The buffer size exceeds the size of the data texture.');
       }
       const dataTextureByteSize = MemoryManager.bufferWidthLength * MemoryManager.bufferHeightLength * 4 * 4;
-      const concatArrayBuffer = MiscUtil.concatArrayBuffers(
-        [buffer.getArrayBuffer()],
-        [buffer.takenSizeInByte],
-        [0],
-        dataTextureByteSize);
+      const concatArrayBuffer = MiscUtil.concatArrayBuffers2({
+        finalSize: dataTextureByteSize,
+        srcs: [buffer.getArrayBuffer()],
+        srcsCopySize: [buffer.takenSizeInByte],
+        srcsOffset: [0]
+      });
       const floatDataTextureBuffer = new Float32Array(concatArrayBuffer);
 
       if (this.__webglResourceRepository.currentWebGLContextWrapper!.isWebGL2) {

--- a/src/webgl/getRenderingStrategy.ts
+++ b/src/webgl/getRenderingStrategy.ts
@@ -5,12 +5,9 @@ import WebGLStrategyFastest from "./WebGLStrategyFastest";
 
 const getRenderingStrategy = function (processApproach: ProcessApproachEnum): WebGLStrategy {
   // Strategy
-  if (processApproach.index === ProcessApproach.FastestWebGL1.index || 
-      processApproach.index === ProcessApproach.FastestWebGL2.index
-    ) {
+  if (ProcessApproach.isFastestApproach(processApproach)) {
     return WebGLStrategyFastest.getInstance();
-  } else if (processApproach.index === ProcessApproach.UniformWebGL1.index ||
-    processApproach.index === ProcessApproach.UniformWebGL2.index) {
+  } else if (ProcessApproach.isUniformApproach(processApproach)) {
     return WebGLStrategyUniform.getInstance();
   }
   return WebGLStrategyUniform.getInstance();

--- a/src/webgl/shaders/GLSLShader.ts
+++ b/src/webgl/shaders/GLSLShader.ts
@@ -586,8 +586,7 @@ vec3 descramble(vec3 v) {
 
   get mainPrerequisites() {
     const processApproach = SystemState.currentProcessApproach;
-    if (processApproach === ProcessApproach.FastestWebGL1 ||
-      processApproach === ProcessApproach.FastestWebGL2) {
+    if (ProcessApproach.isFastestApproach(processApproach)) {
       return `
   float materialSID = u_currentComponentSIDs[0];
 


### PR DESCRIPTION
This PR includes the following loading speed optimizations.

- Add the faster concatArrayBuffer function named `concatArrayBuffer2`
- Skip the `gl.getUniformLocation()` if the `isUniformExist` is false.
  - where `isUniformExist` is `CompositionType.isTexture(info.compositionType) || info.needUniformInFastest || ProcessApproach.isUniformApproach(System.getInstance().processApproach);`

This PR also includes the following fixes.

- Fix to work properly with isDebugMode == false
- Add the `this.__width = 1;` and `this.__height = 1;` to Texture::generate1x1TextureFrom function

Rhodonite works faster if you pass `false` to the  `isDebug` argument of System::setProcessApproachAndCanvas method like this.

```javascript
  const isDebug = false;
  const gl = system.setProcessApproachAndCanvas(strategy, canvas as any, 1, { preserveDrawingBuffer: true }, isDebug);
```