### PR TITLE
Fix initialization of othographic camera

### DIFF
--- a/src/foundation/importer/ModelConverter.ts
+++ b/src/foundation/importer/ModelConverter.ts
@@ -454,7 +454,7 @@ export default class ModelConverter {
       cameraComponent.zNear = camera.perspective.znear;
       cameraComponent.zFar = camera.perspective.zfar ? camera.perspective.zfar : 100000;
     } else if (cameraComponent.type === CameraType.Orthographic) {
-      cameraComponent.xMag = camera.orthographic.zmag;
+      cameraComponent.xMag = camera.orthographic.xmag;
       cameraComponent.yMag = camera.orthographic.ymag;
       cameraComponent.zNear = camera.orthographic.znear;
       cameraComponent.zFar = camera.orthographic.zfar;


### PR DESCRIPTION
Fixes: https://github.com/actnwit/RhodoniteTS/issues/701

## Description
Fixed a problem where OrthographicCamera defined in glTFs could not be loaded correctly.

An undefined value was being assigned to xmag, so it has been changed so that it is assigned correctly.

## Render changes due to changes

Tried tendering [Camera.gltf](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Cameras/glTF)

### Before (Not rendered)

<img width="300" alt="Screen Shot 2021-02-09 at 21 02 07" src="https://user-images.githubusercontent.com/5725274/108009660-849f8300-7046-11eb-9540-5f4340d99a83.png">

### After

<img width="300" alt="Screen Shot 2021-02-16 at 10 56 22" src="https://user-images.githubusercontent.com/5725274/108009724-a3057e80-7046-11eb-8e3e-eccc8a37e58f.png">

### Babylon Viewer (For reference)

<img width="300" alt="Screen Shot 2021-02-09 at 21 00 58" src="https://user-images.githubusercontent.com/5725274/108009897-00013480-7047-11eb-822e-809a97a67fa2.png">

