### PR TITLE
improvement: simplify the shader semantics parameter in ShadowMapDecodeClassicSingleMaterialNode

### DIFF
--- a/samples/test_e2e/ShadowMap/main.ts
+++ b/samples/test_e2e/ShadowMap/main.ts
@@ -74,6 +74,11 @@ document.body.appendChild(p);
     Rn.ShaderSemantics.DiffuseColorFactor,
     new Rn.Vector4(0.1, 0.7, 0.5, 1)
   );
+  setParameterForMeshComponent(
+    meshComponentLargeBoard,
+    Rn.ShadowMapDecodeClassicSingleMaterialNode.ShadowColorFactor,
+    new Rn.Vector4(0.05, 0.35, 0.25, 1)
+  );
 
   const scaleSmallBoard = new Rn.Vector3(0.2, 0.2, 0.2);
   const translateSmallBoard = new Rn.Vector3(0.0, 0.0, -1.0);

--- a/samples/test_e2e/ShadowMapDebugMode/main.ts
+++ b/samples/test_e2e/ShadowMapDebugMode/main.ts
@@ -79,6 +79,11 @@ document.body.appendChild(p);
     Rn.ShadowMapDecodeClassicSingleMaterialNode.DebugColorFactor,
     new Rn.Vector4(0.85, 0.0, 0.0, 1.0)
   );
+  setParameterForMeshComponent(
+    meshComponentLargeBoard,
+    Rn.ShadowMapDecodeClassicSingleMaterialNode.ShadowColorFactor,
+    new Rn.Vector4(0.05, 0.35, 0.25, 1)
+  );
 
   const scaleSmallBoard = new Rn.Vector3(0.2, 0.2, 0.2);
   const translateSmallBoard = new Rn.Vector3(0.0, 0.0, -1.0);

--- a/src/foundation/materials/singles/ShadowMapDecodeClassicSingleMaterialNode.ts
+++ b/src/foundation/materials/singles/ShadowMapDecodeClassicSingleMaterialNode.ts
@@ -30,9 +30,9 @@ import shadowMapDecodeSingleShaderVertex from '../../../webgl/shaderity_shaders/
 import shadowMapDecodeSingleShaderFragment from '../../../webgl/shaderity_shaders/ShadowMapDecodeClassicSingleShader/ShadowMapDecodeClassicSingleShader.frag';
 
 export default class ShadowMapDecodeClassicSingleMaterialNode extends AbstractMaterialNode {
-  static ShadowColorCoefficient: ShaderSemanticsEnum = new ShaderSemanticsClass(
-    {str: 'shadowColorCoefficient'}
-  );
+  static ShadowColorFactor: ShaderSemanticsEnum = new ShaderSemanticsClass({
+    str: 'shadowColorFactor',
+  });
   static ShadowAlpha: ShaderSemanticsEnum = new ShaderSemanticsClass({
     str: 'shadowAlpha',
   });
@@ -152,8 +152,7 @@ export default class ShadowMapDecodeClassicSingleMaterialNode extends AbstractMa
         max: 1,
       },
       {
-        semantic:
-          ShadowMapDecodeClassicSingleMaterialNode.ShadowColorCoefficient,
+        semantic: ShadowMapDecodeClassicSingleMaterialNode.ShadowColorFactor,
         compositionType: CompositionType.Vec4,
         componentType: ComponentType.Float,
         stage: ShaderType.PixelShader,

--- a/src/webgl/shaderity_shaders/ShadowMapDecodeClassicSingleShader/ShadowMapDecodeClassicSingleShader.frag
+++ b/src/webgl/shaderity_shaders/ShadowMapDecodeClassicSingleShader/ShadowMapDecodeClassicSingleShader.frag
@@ -78,9 +78,9 @@ void main (){
 
     if(measureDepth > textureDepth + allowableDepthError){
       // case of shadow
-      vec4 shadowColorCoefficient = get_shadowColorCoefficient(materialSID, 0);
-      diffuseColor *= shadowColorCoefficient.rgb;
-      alpha *= shadowColorCoefficient.a;
+      vec4 shadowColorFactor = get_shadowColorFactor(materialSID, 0);
+      diffuseColor = shadowColorFactor.rgb;
+      alpha = shadowColorFactor.a;
     }
   }
 

--- a/src/webgl/shaders/ShadowMapDecodeClassicShader.ts
+++ b/src/webgl/shaders/ShadowMapDecodeClassicShader.ts
@@ -201,9 +201,9 @@ void main (){
 
     if(measureDepth > textureDepth + allowableDepthError){
       // case of shadow
-      vec4 shadowColorCoefficient = get_shadowColorCoefficient(materialSID, 0);
-      diffuseColor *= shadowColorCoefficient.rgb;
-      alpha *= shadowColorCoefficient.a;
+      vec4 shadowColorFactor = get_shadowColorFactor(materialSID, 0);
+      diffuseColor = shadowColorFactor.rgb;
+      alpha = shadowColorFactor.a;
     }
   }
 


### PR DESCRIPTION
# Changes
- Change the specification of shadow mapping (see below)

## specification change of shadow mapping
I changed the colour specification of the shadow area like following:

before: (shadow colour) = (diffuse colour) * (shadow coefficient)

after:  (shadow colour) = (shadow colour)