### PR TITLE
fix: the normal texture of PBR Shader

### DIFF
--- a/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
+++ b/src/foundation/materials/singles/PbrShadingSingleMaterialNode.ts
@@ -449,7 +449,7 @@ export default class PbrShadingSingleMaterialNode extends AbstractMaterialNode {
           max: Number.MAX_SAFE_INTEGER,
           isSystem: false,
           updateInterval: ShaderVariableUpdateInterval.FirstTimeOnly,
-          initialValue: [2, AbstractMaterialNode.__dummyBlackTexture],
+          initialValue: [2, AbstractMaterialNode.__dummyBlueTexture],
         },
         {
           semantic: PbrShadingSingleMaterialNode.NormalTextureTransform,


### PR DESCRIPTION
I think the default normal texture values should be "blue" (127, 127, 255, 1).

But currently, some of the E2E tests fail in the fixed version.

We should investigate this.



┆Issue is synchronized with this [Wrike Item](https://www.wrike.com/open.htm?id=750297463)
