### PR TITLE
fix: support the image data stored in the bufferView of gltf2.0

### DIFF
--- a/src/foundation/importer/AnimationAssigner.ts
+++ b/src/foundation/importer/AnimationAssigner.ts
@@ -6,7 +6,7 @@ import AnimationComponent from '../components/AnimationComponent';
 import {AnimationInterpolation} from '../definitions/AnimationInterpolation';
 import {Index} from '../../types/CommonTypes';
 import {VRM} from '../../types/VRM';
-import { Is } from '../misc/Is';
+import {Is} from '../misc/Is';
 
 export default class AnimationAssigner {
   private static __instance: AnimationAssigner;

--- a/src/foundation/importer/DrcPointCloudImporter.ts
+++ b/src/foundation/importer/DrcPointCloudImporter.ts
@@ -150,9 +150,8 @@ export default class DrcPointCloudImporter {
       typeof options.loaderExtensionName === 'string'
     ) {
       if (Rn[options.loaderExtensionName] != null) {
-        defaultOptions.loaderExtension = Rn[
-          options.loaderExtensionName
-        ].getInstance();
+        defaultOptions.loaderExtension =
+          Rn[options.loaderExtensionName].getInstance();
       } else {
         console.error(`${options.loaderExtensionName} not found!`);
         defaultOptions.loaderExtension = void 0;
@@ -341,7 +340,7 @@ export default class DrcPointCloudImporter {
           node.extensions.KHR_lights_punctual.light;
         node.extensions.KHR_lights_punctual.light =
           gltfJson.extensions.KHR_lights_punctual.lights[
-          node.extensions.KHR_lights_punctual.lightIndex
+            node.extensions.KHR_lights_punctual.lightIndex
           ];
       }
     }
@@ -556,7 +555,7 @@ export default class DrcPointCloudImporter {
     // BufferView
     for (const bufferView of gltfJson.bufferViews) {
       if (bufferView.buffer !== void 0) {
-        bufferView.bufferIndex = (bufferView.buffer as any) as number;
+        bufferView.bufferIndex = bufferView.buffer as any as number;
         bufferView.buffer = gltfJson.buffers[bufferView.bufferIndex!];
       }
     }
@@ -695,7 +694,7 @@ export default class DrcPointCloudImporter {
 
     // Textures Async load
     for (const _i in gltfJson.images) {
-      const i = (_i as any) as number;
+      const i = _i as any as number;
       const imageJson = gltfJson.images[i] as Gltf2Image;
       //let imageJson = gltfJson.images[textureJson.source];
       //let samplerJson = gltfJson.samplers[textureJson.sampler];

--- a/src/foundation/importer/Gltf1Importer.ts
+++ b/src/foundation/importer/Gltf1Importer.ts
@@ -196,20 +196,8 @@ export default class Gltf1Importer {
   ): Promise<any> {
     const promises = [] as Promise<any>[];
 
-    const resources = {
-      shaders: [],
-      buffers: [],
-      images: [],
-    };
     promises.push(
-      this._loadResources(
-        uint8array!,
-        gltfJson,
-        files,
-        options,
-        resources,
-        basePath
-      )
+      this._loadResources(uint8array!, gltfJson, files, options, basePath)
     );
     promises.push(
       new Promise((resolve, reject) => {
@@ -670,11 +658,6 @@ export default class Gltf1Importer {
     gltfJson: glTF1,
     files: GltfFileBuffers,
     options: GltfLoadOption,
-    resources: {
-      shaders: any[];
-      buffers: any[];
-      images: any[];
-    },
     basePath?: string
   ) {
     const promisesToLoadResources = [];
@@ -692,7 +675,6 @@ export default class Gltf1Importer {
       if (typeof bufferInfo.uri === 'undefined') {
         promisesToLoadResources.push(
           new Promise((resolve, rejected) => {
-            resources.buffers[i] = uint8Array;
             bufferInfo.buffer = uint8Array;
             resolve(gltfJson);
           })
@@ -700,7 +682,6 @@ export default class Gltf1Importer {
       } else if (bufferInfo.uri === '' || bufferInfo.uri === 'data:,') {
         promisesToLoadResources.push(
           new Promise((resolve, rejected) => {
-            resources.buffers[i] = uint8Array;
             bufferInfo.buffer = uint8Array;
             resolve(gltfJson);
           })
@@ -709,7 +690,6 @@ export default class Gltf1Importer {
         promisesToLoadResources.push(
           new Promise((resolve, rejected) => {
             const arrayBuffer = DataUtil.dataUriToArrayBuffer(bufferInfo.uri);
-            resources.buffers[i] = new Uint8Array(arrayBuffer);
             bufferInfo.buffer = new Uint8Array(arrayBuffer);
             resolve(gltfJson);
           })
@@ -719,7 +699,6 @@ export default class Gltf1Importer {
           new Promise((resolve, reject) => {
             const fullPath = this.__getFullPathOfFileName(files, filename);
             const arrayBuffer = files[fullPath!];
-            resources.buffers[i] = new Uint8Array(arrayBuffer);
             bufferInfo.buffer = new Uint8Array(arrayBuffer);
             resolve(gltfJson);
           })
@@ -731,7 +710,6 @@ export default class Gltf1Importer {
             basePath + bufferInfo.uri,
             true,
             (resolve: Function, response: any) => {
-              resources.buffers[i] = new Uint8Array(response);
               bufferInfo.buffer = new Uint8Array(response);
               resolve(gltfJson);
             },
@@ -832,7 +810,6 @@ export default class Gltf1Importer {
           imageJson.mimeType!
         ).then(image => {
           image.crossOrigin = 'Anonymous';
-          resources.images[i] = image;
           imageJson.image = image;
         });
         promisesToLoadResources.push(promise);

--- a/src/foundation/importer/Gltf1Importer.ts
+++ b/src/foundation/importer/Gltf1Importer.ts
@@ -845,7 +845,10 @@ export default class Gltf1Importer {
         imageJson.basis = new Uint8Array(files[imageJson.uri!]);
         resolve();
       });
-    } else if (imageUri.match(/ktx2$/)) {
+    } else if (
+      imageUri.match(/ktx2$/) ||
+      (imageJson.bufferView != null && imageJson.mimeType === 'image/ktx2')
+    ) {
       // load ktx2 file from uri or bufferView
       loadImagePromise = new Promise(resolve => {
         fetch(imageUri, {mode: 'cors'}).then(response => {

--- a/src/foundation/importer/Gltf1Importer.ts
+++ b/src/foundation/importer/Gltf1Importer.ts
@@ -644,10 +644,8 @@ export default class Gltf1Importer {
       extendedJson = JSON.parse(extendedJsonStr);
     } else if (typeof extendedData === 'string') {
       extendedJson = JSON.parse(extendedData);
-      extendedJson = extendedJson;
     } else if (typeof extendedData === 'object') {
       extendedJson = extendedData;
-    } else {
     }
 
     Object.assign(gltfJson, extendedJson);

--- a/src/foundation/importer/Gltf1Importer.ts
+++ b/src/foundation/importer/Gltf1Importer.ts
@@ -1,5 +1,11 @@
 import DataUtil from '../misc/DataUtil';
-import {glTF1, glTF2, Gltf2Image, GltfFileBuffers, GltfLoadOption} from '../../types/glTF';
+import {
+  glTF1,
+  glTF2,
+  Gltf2Image,
+  GltfFileBuffers,
+  GltfLoadOption,
+} from '../../types/glTF';
 
 declare let Rn: any;
 
@@ -39,7 +45,10 @@ export default class Gltf1Importer {
     );
   }
 
-  async importGltfOrGlbFromFile(uri: string, options?: GltfLoadOption): Promise<glTF2|undefined> {
+  async importGltfOrGlbFromFile(
+    uri: string,
+    options?: GltfLoadOption
+  ): Promise<glTF2 | undefined> {
     const arrayBuffer = await DataUtil.fetchArrayBuffer(uri);
     const glTFJson = await this.importGltfOrGlbFromArrayBuffers(
       arrayBuffer,
@@ -101,9 +110,8 @@ export default class Gltf1Importer {
       typeof options.loaderExtensionName === 'string'
     ) {
       if (Rn[options.loaderExtensionName] != null) {
-        defaultOptions.loaderExtension = Rn[
-          options.loaderExtensionName
-        ].getInstance();
+        defaultOptions.loaderExtension =
+          Rn[options.loaderExtensionName].getInstance();
       } else {
         console.error(`${options.loaderExtensionName} not found!`);
         defaultOptions.loaderExtension = void 0;
@@ -481,17 +489,17 @@ export default class Gltf1Importer {
                 (material.technique === 'CONSTANT' && valueName === 'ambient')
               ) {
                 origMaterial.diffuseColorTexture = {};
-                origMaterial.diffuseColorTexture.texture = (gltfJson.textures as any)[
-                  value
-                ];
+                origMaterial.diffuseColorTexture.texture = (
+                  gltfJson.textures as any
+                )[value];
               } else if (
                 valueName === 'emission' &&
                 textureStr.match(/_normal$/)
               ) {
                 origMaterial.emissionTexture = {};
-                origMaterial.emissionTexture.texture = (gltfJson.textures as any)[
-                  value
-                ];
+                origMaterial.emissionTexture.texture = (
+                  gltfJson.textures as any
+                )[value];
               }
               origMaterial.extras = {};
               origMaterial.extras.technique = material.technique;

--- a/src/foundation/importer/Gltf1Importer.ts
+++ b/src/foundation/importer/Gltf1Importer.ts
@@ -809,7 +809,7 @@ export default class Gltf1Importer {
           resolve();
         }) as Promise<void>;
         promisesToLoadResources.push(promise);
-      } else if (imageUri && imageJson.mimeType === 'image/ktx2') {
+      } else if (imageUri.match(/ktx2$/)) {
         const promise = new Promise(resolve => {
           fetch(imageUri, {mode: 'cors'}).then(response => {
             response.arrayBuffer().then(buffer => {

--- a/src/foundation/importer/Gltf1Importer.ts
+++ b/src/foundation/importer/Gltf1Importer.ts
@@ -720,12 +720,7 @@ export default class Gltf1Importer {
     }
 
     // Textures Async load
-    for (const _i in gltfJson.images) {
-      const i = (_i as any) as number;
-      const imageJson = gltfJson.images[i];
-      //let imageJson = gltfJson.images[textureJson.source];
-      //let samplerJson = gltfJson.samplers[textureJson.sampler];
-
+    for (const imageJson of gltfJson.images ?? []) {
       let imageUri: string;
 
       if (

--- a/src/foundation/importer/Gltf2Importer.ts
+++ b/src/foundation/importer/Gltf2Importer.ts
@@ -714,7 +714,7 @@ export default class Gltf2Importer {
           resolve();
         }) as Promise<void>;
         promisesToLoadResources.push(promise);
-      } else if (imageUri && imageJson.mimeType === 'image/ktx2') {
+      } else if (imageUri.match(/ktx2$/)) {
         const promise = new Promise(resolve => {
           fetch(imageUri, {mode: 'cors'}).then(response => {
             response.arrayBuffer().then(buffer => {

--- a/src/foundation/importer/Gltf2Importer.ts
+++ b/src/foundation/importer/Gltf2Importer.ts
@@ -630,12 +630,7 @@ export default class Gltf2Importer {
     }
 
     // Textures Async load
-    for (const _i in gltfJson.images) {
-      const i = (_i as any) as number;
-      const imageJson = gltfJson.images[i] as Gltf2Image;
-      //let imageJson = gltfJson.images[textureJson.source];
-      //let samplerJson = gltfJson.samplers[textureJson.sampler];
-
+    for (const imageJson of gltfJson.images ?? []) {
       let imageUri: string;
 
       if (typeof imageJson.uri === 'undefined') {

--- a/src/foundation/importer/Gltf2Importer.ts
+++ b/src/foundation/importer/Gltf2Importer.ts
@@ -23,7 +23,10 @@ export default class Gltf2Importer {
    * @param options - options for loading process
    * @returns a glTF2 based JSON pre-processed
    */
-  async import(uri: string, options?: GltfLoadOption): Promise<glTF2|undefined> {
+  async import(
+    uri: string,
+    options?: GltfLoadOption
+  ): Promise<glTF2 | undefined> {
     if (options && options.files) {
       for (const fileName in options.files) {
         const fileExtension = DataUtil.getExtension(fileName);
@@ -81,7 +84,7 @@ export default class Gltf2Importer {
     otherFiles: GltfFileBuffers,
     options?: GltfLoadOption,
     uri?: string
-  ): Promise<glTF2|undefined> {
+  ): Promise<glTF2 | undefined> {
     const dataView = new DataView(arrayBuffer, 0, 20);
     // Magic field
     const magic = dataView.getUint32(0, true);
@@ -132,9 +135,8 @@ export default class Gltf2Importer {
       typeof options.loaderExtensionName === 'string'
     ) {
       if (Rn[options.loaderExtensionName] != null) {
-        defaultOptions.loaderExtension = Rn[
-          options.loaderExtensionName
-        ].getInstance();
+        defaultOptions.loaderExtension =
+          Rn[options.loaderExtensionName].getInstance();
       } else {
         console.error(`${options.loaderExtensionName} not found!`);
         defaultOptions.loaderExtension = void 0;

--- a/src/foundation/importer/Gltf2Importer.ts
+++ b/src/foundation/importer/Gltf2Importer.ts
@@ -634,10 +634,9 @@ export default class Gltf2Importer {
       let imageUri: string;
 
       if (typeof imageJson.uri === 'undefined') {
-        let arrayBuffer = uint8Array;
         if (uint8Array == null) {
-          const bufferView = gltfJson.bufferViews[imageJson.bufferView!];
-          arrayBuffer = bufferView.buffer.buffer!;
+          // need to wait for load gltfJson.buffer
+          // imageUint8Array is not correct now
         }
         const imageUint8Array = DataUtil.createUint8ArrayFromBufferViewInfo(
           gltfJson,

--- a/src/foundation/importer/Gltf2Importer.ts
+++ b/src/foundation/importer/Gltf2Importer.ts
@@ -228,22 +228,9 @@ export default class Gltf2Importer {
   ) {
     const promises = [];
 
-    const resources = {
-      shaders: [],
-      buffers: [],
-      images: [],
-    };
-
     // Load resources to above resources object.
     promises.push(
-      this._loadResources(
-        uint8array!,
-        gltfJson,
-        files,
-        options,
-        resources,
-        basePath
-      )
+      this._loadResources(uint8array!, gltfJson, files, options, basePath)
     );
 
     // Parse glTF JSON
@@ -592,11 +579,6 @@ export default class Gltf2Importer {
     gltfJson: glTF2,
     files: GltfFileBuffers,
     options: GltfLoadOption,
-    resources: {
-      shaders: any[];
-      buffers: any[];
-      images: any[];
-    },
     basePath?: string
   ) {
     const promisesToLoadResources = [];
@@ -614,14 +596,12 @@ export default class Gltf2Importer {
 
       if (typeof bufferInfo.uri === 'undefined') {
         rnpArrayBuffer = new RnPromise<ArrayBuffer>((resolve, rejected) => {
-          resources.buffers[i] = uint8Array;
           bufferInfo.buffer = uint8Array;
           resolve(uint8Array);
         });
       } else if (bufferInfo.uri.match(/^data:application\/(.*);base64,/)) {
         rnpArrayBuffer = new RnPromise<ArrayBuffer>((resolve, rejected) => {
           const arrayBuffer = DataUtil.dataUriToArrayBuffer(bufferInfo.uri!);
-          resources.buffers[i] = new Uint8Array(arrayBuffer);
           bufferInfo.buffer = new Uint8Array(arrayBuffer);
           resolve(arrayBuffer);
         });
@@ -629,7 +609,6 @@ export default class Gltf2Importer {
         rnpArrayBuffer = new RnPromise<ArrayBuffer>((resolve, rejected) => {
           const fullPath = this.__getFullPathOfFileName(files, filename);
           const arrayBuffer = files[fullPath!];
-          resources.buffers[i] = new Uint8Array(arrayBuffer);
           bufferInfo.buffer = new Uint8Array(arrayBuffer);
           resolve(arrayBuffer);
         });
@@ -639,7 +618,6 @@ export default class Gltf2Importer {
             basePath + bufferInfo.uri,
             true,
             (resolve: Function, response: ArrayBuffer) => {
-              resources.buffers[i] = new Uint8Array(response);
               bufferInfo.buffer = new Uint8Array(response);
               resolve(response);
             },
@@ -737,7 +715,6 @@ export default class Gltf2Importer {
           imageJson.mimeType!
         ).then(image => {
           image.crossOrigin = 'Anonymous';
-          resources.images[i] = image;
           imageJson.image = image;
         });
         promisesToLoadResources.push(promise);

--- a/src/foundation/importer/GltfImporter.ts
+++ b/src/foundation/importer/GltfImporter.ts
@@ -2,12 +2,7 @@ import Entity from '../core/Entity';
 import EntityRepository from '../core/EntityRepository';
 import {detectFormatByArrayBuffers} from './FormatDetector';
 import Gltf2Importer from './Gltf2Importer';
-import {
-  GltfLoadOption,
-  glTF2,
-  GltfFileBuffers,
-  glTF1,
-} from '../../types/glTF';
+import {GltfLoadOption, glTF2, GltfFileBuffers, glTF1} from '../../types/glTF';
 import ModelConverter from './ModelConverter';
 import PhysicsComponent from '../components/PhysicsComponent';
 import SceneGraphComponent from '../components/SceneGraphComponent';
@@ -24,7 +19,7 @@ import RenderPass from '../renderer/RenderPass';
 import {VRM} from '../../types/VRM';
 import DataUtil from '../misc/DataUtil';
 import {FileType} from '../definitions/FileType';
-import { Is } from '../misc/Is';
+import {Is} from '../misc/Is';
 
 /**
  * Importer class which can import GLTF and VRM.
@@ -45,7 +40,10 @@ export default class GltfImporter {
    * For VRM file only
    * Generate JSON.
    */
-  async importJsonOfVRM(uri: string, options?: GltfLoadOption): Promise<VRM|undefined> {
+  async importJsonOfVRM(
+    uri: string,
+    options?: GltfLoadOption
+  ): Promise<VRM | undefined> {
     options = this._getOptions(options);
 
     const gltf2Importer = Gltf2Importer.getInstance();
@@ -106,10 +104,8 @@ export default class GltfImporter {
   ): Promise<Expression> {
     options = this.__initOptions(options);
 
-    const renderPasses: RenderPass[] = await this.__importMultipleModelsFromArrayBuffers(
-      files,
-      options
-    );
+    const renderPasses: RenderPass[] =
+      await this.__importMultipleModelsFromArrayBuffers(files, options);
 
     if (options && options.cameraComponent) {
       for (const renderPass of renderPasses) {
@@ -316,9 +312,8 @@ export default class GltfImporter {
             importer
               .importGltf(json, options.files!, options, fileName)
               .then(gltfModel => {
-                const rootGroup = modelConverter.convertToRhodoniteObject(
-                  gltfModel
-                );
+                const rootGroup =
+                  modelConverter.convertToRhodoniteObject(gltfModel);
                 renderPasses[0].addEntities([rootGroup]);
                 resolve();
               });
@@ -336,9 +331,8 @@ export default class GltfImporter {
             importer
               .importGlb(fileArrayBuffer, options.files!, options)
               .then(gltfModel => {
-                const rootGroup = modelConverter.convertToRhodoniteObject(
-                  gltfModel
-                );
+                const rootGroup =
+                  modelConverter.convertToRhodoniteObject(gltfModel);
                 renderPasses[0].addEntities([rootGroup]);
                 resolve();
               });
@@ -346,7 +340,8 @@ export default class GltfImporter {
           break;
         case FileType.Draco:
           {
-            const importer = DrcPointCloudImporter.getInstance() as DrcPointCloudImporter;
+            const importer =
+              DrcPointCloudImporter.getInstance() as DrcPointCloudImporter;
             importer
               .importArrayBuffer(uri, fileArrayBuffer, options)
               .then(gltfModel => {
@@ -354,9 +349,8 @@ export default class GltfImporter {
                   console.error('importArrayBuffer error is occurred');
                   reject();
                 } else {
-                  const rootGroup = modelConverter.convertToRhodoniteObject(
-                    gltfModel
-                  );
+                  const rootGroup =
+                    modelConverter.convertToRhodoniteObject(gltfModel);
                   renderPasses[0].addEntities([rootGroup]);
                   resolve();
                 }
@@ -405,7 +399,8 @@ export default class GltfImporter {
       .then(gltfModel_ => {
         const gltfModel = gltfModel_!;
         const defaultMaterialHelperArgumentArray =
-          gltfModel.asset.extras?.rnLoaderOptions?.defaultMaterialHelperArgumentArray;
+          gltfModel.asset.extras?.rnLoaderOptions
+            ?.defaultMaterialHelperArgumentArray;
         if (Is.exist(defaultMaterialHelperArgumentArray)) {
           defaultMaterialHelperArgumentArray[0].textures =
             defaultMaterialHelperArgumentArray[0].textures ??
@@ -571,9 +566,8 @@ export default class GltfImporter {
         colliders.push(sphereCollider);
       }
       vrmColliderGroup.colliders = colliders;
-      const baseSg = gltfModel.asset.extras!.rnEntities![
-        colliderGroup.node
-      ].getSceneGraph();
+      const baseSg =
+        gltfModel.asset.extras!.rnEntities![colliderGroup.node].getSceneGraph();
       vrmColliderGroup.baseSceneGraph = baseSg;
       VRMSpringBonePhysicsStrategy.addColliderGroup(
         parseInt(colliderGroupIdx),
@@ -744,34 +738,31 @@ export default class GltfImporter {
       // this.__initializeForUndefinedProperty(floatProperties,"_UvAnimRotation", 0.0);
 
       const vectorProperties = materialProperties[i].vectorProperties;
-      this.__initializeForUndefinedProperty(vectorProperties, '_Color', [
-        1,
-        1,
-        1,
-        1,
-      ]);
+      this.__initializeForUndefinedProperty(
+        vectorProperties,
+        '_Color',
+        [1, 1, 1, 1]
+      );
       this.__initializeForUndefinedProperty(
         vectorProperties,
         '_EmissionColor',
         [0, 0, 0]
       );
-      this.__initializeForUndefinedProperty(vectorProperties, '_OutlineColor', [
-        0,
-        0,
-        0,
-        1,
-      ]);
-      this.__initializeForUndefinedProperty(vectorProperties, '_ShadeColor', [
-        0.97,
-        0.81,
-        0.86,
-        1,
-      ]);
-      this.__initializeForUndefinedProperty(vectorProperties, '_RimColor', [
-        0,
-        0,
-        0,
-      ]);
+      this.__initializeForUndefinedProperty(
+        vectorProperties,
+        '_OutlineColor',
+        [0, 0, 0, 1]
+      );
+      this.__initializeForUndefinedProperty(
+        vectorProperties,
+        '_ShadeColor',
+        [0.97, 0.81, 0.86, 1]
+      );
+      this.__initializeForUndefinedProperty(
+        vectorProperties,
+        '_RimColor',
+        [0, 0, 0]
+      );
       // this.__initializeForUndefinedProperty(vectorProperties, "_BumpMap", [0, 0, 1, 1]);
       // this.__initializeForUndefinedProperty(vectorProperties, "_EmissionMap", [0, 0, 1, 1]);
       // this.__initializeForUndefinedProperty(vectorProperties, "_MainTex", [0, 0, 1, 1]);


### PR DESCRIPTION
If data of image property of gltf2 is specified by buffer view like the following attached image, the rhodonite cannot load the image data. I fixed it.

![image](https://user-images.githubusercontent.com/7972283/120313792-70da0d00-c315-11eb-8cfd-757493f4b54b.png)