### PR TITLE
feat: enable to configure the sample count for MSAA

### DIFF
--- a/src/foundation/helpers/RenderableHelper.ts
+++ b/src/foundation/helpers/RenderableHelper.ts
@@ -20,6 +20,7 @@ function createTexturesForRenderTarget(
     wrapT = TextureParameter.ClampToEdge,
     createDepthBuffer = true,
     isMSAA = false,
+    sampleCountMSAA = 4,
   }
 ) {
   const frameBuffer = new FrameBuffer();
@@ -44,13 +45,19 @@ function createTexturesForRenderTarget(
 
   if (createDepthBuffer) {
     const renderBuffer = new RenderBuffer();
-    renderBuffer.create(width, height, TextureParameter.Depth16, isMSAA);
+    renderBuffer.create(width, height, TextureParameter.Depth16, {
+      isMSAA,
+      sampleCountMSAA,
+    });
     frameBuffer.setDepthAttachment(renderBuffer);
   }
 
   if (isMSAA) {
     const renderBuffer = new RenderBuffer();
-    renderBuffer.create(width, height, TextureParameter.RGBA8, isMSAA);
+    renderBuffer.create(width, height, TextureParameter.RGBA8, {
+      isMSAA,
+      sampleCountMSAA,
+    });
     frameBuffer.setColorAttachmentAt(textureNum, renderBuffer);
   }
 

--- a/src/foundation/textures/RenderBuffer.ts
+++ b/src/foundation/textures/RenderBuffer.ts
@@ -15,6 +15,7 @@ export default class RenderBuffer extends RnObject implements IRenderable {
   public cgApiResourceUid: CGAPIResourceHandle = -1;
   private __fbo?: FrameBuffer;
   private __isMSAA = false;
+  private __sampleCountMSAA = 4;
 
   constructor() {
     super();
@@ -32,24 +33,27 @@ export default class RenderBuffer extends RnObject implements IRenderable {
     width: Size,
     height: Size,
     internalFormat: TextureParameterEnum,
-    isMSAA: boolean
+    {isMSAA = false, sampleCountMSAA = this.__sampleCountMSAA} = {}
   ) {
     this.width = width;
     this.height = height;
     this.__isMSAA = isMSAA;
+    this.__sampleCountMSAA = sampleCountMSAA;
     this.__internalFormat = internalFormat;
-    const webglResourceRepository = CGAPIResourceRepository.getWebGLResourceRepository();
+    const webglResourceRepository =
+      CGAPIResourceRepository.getWebGLResourceRepository();
     this.cgApiResourceUid = webglResourceRepository.createRenderBuffer(
       width,
       height,
       internalFormat,
-      isMSAA
+      isMSAA,
+      sampleCountMSAA
     );
   }
 
   resize(width: Size, height: Size) {
     this.destroy3DAPIResources();
-    this.create(width, height, this.__internalFormat, this.__isMSAA);
+    this.create(width, height, this.__internalFormat, {isMSAA: this.__isMSAA});
   }
 
   destroy3DAPIResources() {

--- a/src/webgl/WebGLResourceRepository.ts
+++ b/src/webgl/WebGLResourceRepository.ts
@@ -22,7 +22,7 @@ import {MathUtil} from '../foundation/math/MathUtil';
 import {
   ShaderSemanticsInfo,
   ShaderSemantics,
-  ShaderSemanticsName
+  ShaderSemanticsName,
 } from '../foundation/definitions/ShaderSemantics';
 import AbstractTexture from '../foundation/textures/AbstractTexture';
 import RenderTargetTexture from '../foundation/textures/RenderTargetTexture';
@@ -1452,7 +1452,8 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
     width: Size,
     height: Size,
     internalFormat: TextureParameterEnum,
-    isMSAA: boolean
+    isMSAA: boolean,
+    sampleCountMSAA: Count
   ) {
     const gl = this.__glw!.getRawContext();
     const renderBuffer = gl.createRenderbuffer();
@@ -1464,7 +1465,7 @@ export default class WebGLResourceRepository extends CGAPIResourceRepository {
       if (this.__glw!.isWebGL2) {
         (gl as WebGL2RenderingContext).renderbufferStorageMultisample(
           gl.RENDERBUFFER,
-          4,
+          sampleCountMSAA,
           (gl as any)[internalFormat.str],
           width,
           height


### PR DESCRIPTION
Currently, the number of sampling for the MSAA depth value is fixed at 4. In this PR, the number of sampling is selectable.