### PR TITLE
fix: avoid needless cube map loading in MeshRendererComponent.$load

### DIFF
--- a/src/foundation/textures/CubeTexture.ts
+++ b/src/foundation/textures/CubeTexture.ts
@@ -152,6 +152,7 @@ export default class CubeTexture extends AbstractTexture {
     );
 
     this.__isTextureReady = true;
+    this.__startedToLoad = true;
     AbstractTexture.__textureMap.set(this.cgApiResourceUid, this);
   }
 


### PR DESCRIPTION
This PR prevents unwanted loading of the MeshRendererComponent.$load method.

The MeshRendererComponent.$load method tries to load the texture from URI if CubeTexture.__startedToLoad is false, which is not necessary when creating a cube map with a typed array, so we changed CubeTexture.__startedToLoad to true.