### PR TITLE
feat: shaderity material node

### DIFF
--- a/src/foundation/core/GlobalDataRepository.ts
+++ b/src/foundation/core/GlobalDataRepository.ts
@@ -398,6 +398,10 @@ export default class GlobalDataRepository {
     return this.__fields.get(propertyIndex);
   }
 
+  getGlobalProperties() {
+    return Array.from(this.__fields.values());
+  }
+
   setUniformLocations(
     shaderProgramUid: CGAPIResourceHandle,
     isUniformOnlyMode: boolean

--- a/src/foundation/helpers/MaterialHelper.ts
+++ b/src/foundation/helpers/MaterialHelper.ts
@@ -32,6 +32,8 @@ import PbrExtendedShadingSingleMaterialNode from '../materials/singles/PbrExtend
 import Texture from '../textures/Texture';
 import {CameraComponent} from '../..';
 import {Count} from '../../types/CommonTypes';
+import {ShaderityObject} from 'shaderity';
+import ShaderitySingleMaterialNode from '../materials/singles/ShaderitySingleMaterialNode';
 
 function createMaterial(
   materialName: string,
@@ -686,6 +688,29 @@ function recreateCustomMaterial(
   return material;
 }
 
+// create or update shaderity material
+function recreateShaderityMaterial(
+  vertexShaderityObj: ShaderityObject,
+  pixelShaderityObj: ShaderityObject,
+  {
+    additionalName = '',
+    maxInstancesNumber = Config.maxMaterialInstanceForEachType,
+  } = {}
+) {
+  const name = `Shaderity_${additionalName}`;
+
+  const materialNode = new ShaderitySingleMaterialNode({
+    name,
+    vertexShaderityObj,
+    pixelShaderityObj,
+  });
+
+  materialNode.isSingleOperation = true;
+  const material = recreateMaterial(name, [materialNode], maxInstancesNumber);
+
+  return material;
+}
+
 function changeMaterial(
   entity: Entity,
   primitive: Primitive,
@@ -700,6 +725,7 @@ export default Object.freeze({
   createMaterial,
   recreateMaterial,
   recreateCustomMaterial,
+  recreateShaderityMaterial,
   createEmptyMaterial,
   createClassicUberMaterial,
   createPbrUberMaterial,

--- a/src/foundation/materials/core/Material.ts
+++ b/src/foundation/materials/core/Material.ts
@@ -396,6 +396,38 @@ export default class Material extends RnObject {
     });
   }
 
+  // Note: The uniform defined in the GlobalDataRepository and the VertexAttributesExistenceArray,
+  //       WorldMatrix, NormalMatrix, PointSize, and PointDistanceAttenuation cannot be set.
+  setParameterByUniformName(uniformName: string, value: any, index?: Index) {
+    const targetShaderSemantics = this.__getTargetShaderSemantics(uniformName);
+    if (targetShaderSemantics != null) {
+      this.setParameter(targetShaderSemantics, value, index);
+    }
+  }
+
+  setTextureParameterByUniformName(uniformName: string, value: any) {
+    const targetShaderSemantics = this.__getTargetShaderSemantics(uniformName);
+    if (targetShaderSemantics != null) {
+      this.setTextureParameter(targetShaderSemantics, value);
+    }
+  }
+
+  private __getTargetShaderSemantics(uniformName: string) {
+    const targetFieldsInfo = this.fieldsInfoArray.find(fieldsInfo => {
+      const prefix = fieldsInfo.none_u_prefix ? '' : 'u_';
+      return prefix + fieldsInfo.semantic.str === uniformName;
+    });
+
+    if (targetFieldsInfo == null) {
+      console.error(
+        `Material.__getTargetShaderSemantics: uniform ${uniformName} is not found`
+      );
+      return;
+    }
+
+    return targetFieldsInfo.semantic;
+  }
+
   setParameter(shaderSemantic: ShaderSemanticsEnum, value: any, index?: Index) {
     const propertyIndex = Material._getPropertyIndex2(shaderSemantic, index);
     const info = this.__fieldsInfo.get(propertyIndex);

--- a/src/foundation/materials/singles/ShaderitySingleMaterialNode.ts
+++ b/src/foundation/materials/singles/ShaderitySingleMaterialNode.ts
@@ -44,6 +44,23 @@ export default class ShaderitySingleMaterialNode extends AbstractMaterialNode {
       }
     }
 
+    const globalPropertyStructs =
+      GlobalDataRepository.getInstance().getGlobalProperties();
+    for (const globalPropertyStruct of globalPropertyStructs) {
+      const globalShaderSemanticsInfo =
+        globalPropertyStruct.shaderSemanticsInfo;
+
+      const duplicateElemId = shaderSemanticsInfoArray.findIndex(
+        shaderSemanticsInfo =>
+          shaderSemanticsInfo.semantic.str ===
+          globalShaderSemanticsInfo.semantic.str
+      );
+
+      if (duplicateElemId !== -1) {
+        shaderSemanticsInfoArray.splice(duplicateElemId, 1);
+      }
+    }
+
     this.setShaderSemanticsInfoArray(shaderSemanticsInfoArray);
   }
 

--- a/src/foundation/materials/singles/ShaderitySingleMaterialNode.ts
+++ b/src/foundation/materials/singles/ShaderitySingleMaterialNode.ts
@@ -2,6 +2,8 @@ import {ShaderSemanticsInfo} from '../../definitions/ShaderSemantics';
 import AbstractMaterialNode from '../core/AbstractMaterialNode';
 import Material from '../core/Material';
 import {ShaderityObject} from 'shaderity';
+import ShaderityUtility from '../core/ShaderityUtility';
+import {ShaderType} from '../../definitions/ShaderType';
 
 export default class ShaderitySingleMaterialNode extends AbstractMaterialNode {
   constructor({
@@ -15,10 +17,33 @@ export default class ShaderitySingleMaterialNode extends AbstractMaterialNode {
   }) {
     super(null, name, {});
 
+    const vertexShaderData = ShaderityUtility.getShaderDataRefection(
+      vertexShaderityObj,
+      AbstractMaterialNode.__semanticsMap.get(this.shaderFunctionName)
+    );
+    const pixelShaderData = ShaderityUtility.getShaderDataRefection(
+      pixelShaderityObj,
+      AbstractMaterialNode.__semanticsMap.get(this.shaderFunctionName)
+    );
     this.__vertexShaderityObject = vertexShaderityObj;
     this.__pixelShaderityObject = pixelShaderityObj;
 
-    const shaderSemanticsInfoArray: ShaderSemanticsInfo[] = [];
+    const shaderSemanticsInfoArray: ShaderSemanticsInfo[] =
+      vertexShaderData.shaderSemanticsInfoArray.concat();
+
+    for (const pixelShaderSemanticsInfo of pixelShaderData.shaderSemanticsInfoArray) {
+      const foundShaderSemanticsInfo = shaderSemanticsInfoArray.find(
+        (info: ShaderSemanticsInfo) => {
+          return info.semantic.str === pixelShaderSemanticsInfo.semantic.str;
+        }
+      );
+      if (foundShaderSemanticsInfo) {
+        foundShaderSemanticsInfo.stage = ShaderType.VertexAndPixelShader;
+      } else {
+        shaderSemanticsInfoArray.push(pixelShaderSemanticsInfo);
+      }
+    }
+
     this.setShaderSemanticsInfoArray(shaderSemanticsInfoArray);
   }
 

--- a/src/foundation/materials/singles/ShaderitySingleMaterialNode.ts
+++ b/src/foundation/materials/singles/ShaderitySingleMaterialNode.ts
@@ -1,0 +1,36 @@
+import {ShaderSemanticsInfo} from '../../definitions/ShaderSemantics';
+import AbstractMaterialNode from '../core/AbstractMaterialNode';
+import Material from '../core/Material';
+import {ShaderityObject} from 'shaderity';
+
+export default class ShaderitySingleMaterialNode extends AbstractMaterialNode {
+  constructor({
+    name,
+    vertexShaderityObj,
+    pixelShaderityObj,
+  }: {
+    name: string;
+    vertexShaderityObj: ShaderityObject;
+    pixelShaderityObj: ShaderityObject;
+  }) {
+    super(null, name, {});
+
+    this.__vertexShaderityObject = vertexShaderityObj;
+    this.__pixelShaderityObject = pixelShaderityObj;
+
+    const shaderSemanticsInfoArray: ShaderSemanticsInfo[] = [];
+    this.setShaderSemanticsInfoArray(shaderSemanticsInfoArray);
+  }
+
+  setParametersForGPU({
+    material,
+    shaderProgram,
+    firstTime,
+    args,
+  }: {
+    material: Material;
+    shaderProgram: WebGLProgram;
+    firstTime: boolean;
+    args?: any;
+  }) {}
+}

--- a/src/foundation/materials/singles/ShaderitySingleMaterialNode.ts
+++ b/src/foundation/materials/singles/ShaderitySingleMaterialNode.ts
@@ -1,9 +1,13 @@
-import {ShaderSemanticsInfo} from '../../definitions/ShaderSemantics';
+import {
+  ShaderSemantics,
+  ShaderSemanticsInfo,
+} from '../../definitions/ShaderSemantics';
 import AbstractMaterialNode from '../core/AbstractMaterialNode';
 import Material from '../core/Material';
 import {ShaderityObject} from 'shaderity';
 import ShaderityUtility from '../core/ShaderityUtility';
 import {ShaderType} from '../../definitions/ShaderType';
+import GlobalDataRepository from '../../core/GlobalDataRepository';
 
 export default class ShaderitySingleMaterialNode extends AbstractMaterialNode {
   constructor({
@@ -44,22 +48,9 @@ export default class ShaderitySingleMaterialNode extends AbstractMaterialNode {
       }
     }
 
-    const globalPropertyStructs =
-      GlobalDataRepository.getInstance().getGlobalProperties();
-    for (const globalPropertyStruct of globalPropertyStructs) {
-      const globalShaderSemanticsInfo =
-        globalPropertyStruct.shaderSemanticsInfo;
-
-      const duplicateElemId = shaderSemanticsInfoArray.findIndex(
-        shaderSemanticsInfo =>
-          shaderSemanticsInfo.semantic.str ===
-          globalShaderSemanticsInfo.semantic.str
-      );
-
-      if (duplicateElemId !== -1) {
-        shaderSemanticsInfoArray.splice(duplicateElemId, 1);
-      }
-    }
+    ShaderitySingleMaterialNode.__removeUselessShaderSemantics(
+      shaderSemanticsInfoArray
+    );
 
     this.setShaderSemanticsInfoArray(shaderSemanticsInfoArray);
   }
@@ -75,4 +66,45 @@ export default class ShaderitySingleMaterialNode extends AbstractMaterialNode {
     firstTime: boolean;
     args?: any;
   }) {}
+
+  private static __removeUselessShaderSemantics(
+    shaderSemanticsInfoArray: ShaderSemanticsInfo[]
+  ) {
+    const globalPropertyStructs =
+      GlobalDataRepository.getInstance().getGlobalProperties();
+
+    for (const globalPropertyStruct of globalPropertyStructs) {
+      const globalShaderSemanticsInfo =
+        globalPropertyStruct.shaderSemanticsInfo;
+
+      const duplicateElemId = shaderSemanticsInfoArray.findIndex(
+        shaderSemanticsInfo =>
+          shaderSemanticsInfo.semantic.str ===
+          globalShaderSemanticsInfo.semantic.str
+      );
+
+      if (duplicateElemId !== -1) {
+        shaderSemanticsInfoArray.splice(duplicateElemId, 1);
+      }
+    }
+
+    const defaultShaderSemantics = [
+      ShaderSemantics.VertexAttributesExistenceArray,
+      ShaderSemantics.WorldMatrix,
+      ShaderSemantics.NormalMatrix,
+      ShaderSemantics.PointSize,
+      ShaderSemantics.PointDistanceAttenuation,
+    ];
+
+    for (const shaderSemantic of defaultShaderSemantics) {
+      const duplicateElemId = shaderSemanticsInfoArray.findIndex(
+        shaderSemanticsInfo =>
+          shaderSemanticsInfo.semantic.str === shaderSemantic.str
+      );
+
+      if (duplicateElemId !== -1) {
+        shaderSemanticsInfoArray.splice(duplicateElemId, 1);
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR supports a material that is created by Shaderity.ShaderityObjectCreator.

Currently, this material node can be used when the webgl strategy is 'uniform' only