### PR TITLE
refactor: separate getShaderDataRefection method in shaderity utility

### DIFF
--- a/src/foundation/materials/core/ShaderityUtility.ts
+++ b/src/foundation/materials/core/ShaderityUtility.ts
@@ -208,23 +208,26 @@ export default class ShaderityUtility {
     shaderSemanticsInfo.componentType = ComponentType.fromGlslString(type);
     shaderSemanticsInfo.compositionType = CompositionType.fromGlslString(type);
 
+    this.__setRhodoniteOriginalParametersTo(shaderSemanticsInfo, info);
+
+    return shaderSemanticsInfo;
+  }
+
+  private static __setRhodoniteOriginalParametersTo(
+    shaderSemanticsInfo: ShaderSemanticsInfo,
+    info: string
+  ) {
     const soloDatum = info.match(/soloDatum[\t ]*=[\t ]*(\w+)[,\t ]*/);
-    let bool = false;
-    if (soloDatum) {
-      const soloDatumText = soloDatum[1];
-      if (soloDatumText === 'true') {
-        bool = true;
-      }
+    let isSoloDatumFlg = false;
+    if (soloDatum?.[1] === 'true') {
+      isSoloDatumFlg = true;
     }
-    shaderSemanticsInfo.soloDatum = bool;
+    shaderSemanticsInfo.soloDatum = isSoloDatumFlg;
 
     const isSystem = info.match(/isSystem[\t ]*=[\t ]*(\w+)[,\t ]*/);
     let isSystemFlg = false;
-    if (isSystem) {
-      const isSystemText = isSystem[1];
-      if (isSystemText === 'true') {
-        isSystemFlg = true;
-      }
+    if (isSystem?.[1] === 'true') {
+      isSystemFlg = true;
     }
     shaderSemanticsInfo.isSystem = isSystemFlg;
 
@@ -232,11 +235,8 @@ export default class ShaderityUtility {
       /updateInterval[\t ]*=[\t ]*(\w+)[,\t ]*/
     );
     let updateIntervalObj = ShaderVariableUpdateInterval.FirstTimeOnly;
-    if (updateInterval) {
-      const updateIntervalText = updateInterval[1];
-      if (updateIntervalText.toLowerCase() === 'everytime') {
-        updateIntervalObj = ShaderVariableUpdateInterval.EveryTime;
-      }
+    if (updateInterval?.[1]?.toLowerCase() === 'everytime') {
+      updateIntervalObj = ShaderVariableUpdateInterval.EveryTime;
     }
     shaderSemanticsInfo.updateInterval = updateIntervalObj;
 
@@ -251,8 +251,6 @@ export default class ShaderityUtility {
       shaderSemanticsInfo.initialValue =
         this.__getDefaultInitialValue(shaderSemanticsInfo);
     }
-
-    return shaderSemanticsInfo;
   }
 
   private static __getInitialValueFromText(

--- a/src/foundation/materials/core/ShaderityUtility.ts
+++ b/src/foundation/materials/core/ShaderityUtility.ts
@@ -32,6 +32,7 @@ import MutableVector4 from '../../math/MutableVector4';
 import MutableMatrix33 from '../../math/MutableMatrix33';
 import MutableMatrix44 from '../../math/MutableMatrix44';
 import MutableScalar from '../../math/MutableScalar';
+import MutableMatrix22 from '../../math/MutableMatrix22';
 
 export type FillArgsObject = {
   [key: string]: string;
@@ -369,6 +370,8 @@ export default class ShaderityUtility {
       return MutableVector3.zero();
     } else if (shaderSemanticsInfo.compositionType === CompositionType.Vec4) {
       return MutableVector4.zero();
+    } else if (shaderSemanticsInfo.compositionType === CompositionType.Mat2) {
+      return MutableMatrix22.identity();
     } else if (shaderSemanticsInfo.compositionType === CompositionType.Mat3) {
       return MutableMatrix33.identity();
     } else if (shaderSemanticsInfo.compositionType === CompositionType.Mat4) {

--- a/src/foundation/materials/core/ShaderityUtility.ts
+++ b/src/foundation/materials/core/ShaderityUtility.ts
@@ -128,12 +128,9 @@ export default class ShaderityUtility {
         const variableName = matchUniformDeclaration[2];
         const info = matchUniformDeclaration[4];
 
-        const skipProcess = info.match(/skipProcess[\t ]*=[\t ]*(\w+)[,\t ]*/);
-        if (skipProcess) {
-          if (skipProcess[1] === 'true') {
-            uniformOmittedShaderRows.push(row);
-            continue;
-          }
+        if (this.__ignoreThisUniformDeclaration(info)) {
+          uniformOmittedShaderRows.push(row);
+          continue;
         }
 
         const shaderSemanticsInfo = this.__createShaderSemanticsInfo(
@@ -165,6 +162,14 @@ export default class ShaderityUtility {
     };
 
     return copiedObj;
+  }
+
+  private static __ignoreThisUniformDeclaration(info: string) {
+    const skipProcess = info.match(/skipProcess[\t ]*=[\t ]*(\w+)[,\t ]*/);
+    if (skipProcess?.[1] === 'true') {
+      return true;
+    }
+    return false;
   }
 
   private static __createShaderSemanticsInfo(

--- a/src/foundation/materials/core/ShaderityUtility.ts
+++ b/src/foundation/materials/core/ShaderityUtility.ts
@@ -121,20 +121,12 @@ export default class ShaderityUtility {
     for (const row of splitCode) {
       const reg =
         /^(?![/])[\t ]*uniform[\t ]+(\w+)[\t ]+(\w+);[\t ]*(\/\/)*[\t ]*(.*)/;
-      const match = row.match(reg);
+      const matchUniformDeclaration = row.match(reg);
 
-      if (match) {
-        const shaderSemanticsInfo: any = {};
-        const type = match[1];
-        let variableName = match[2];
-        const u_prefixedName = variableName.match(/u_(\w+)/);
-        if (u_prefixedName) {
-          variableName = u_prefixedName[1];
-          shaderSemanticsInfo.none_u_prefix = false;
-        } else {
-          shaderSemanticsInfo.none_u_prefix = true;
-        }
-        const info = match[4];
+      if (matchUniformDeclaration) {
+        const type = matchUniformDeclaration[1];
+        const variableName = matchUniformDeclaration[2];
+        const info = matchUniformDeclaration[4];
 
         const skipProcess = info.match(/skipProcess[\t ]*=[\t ]*(\w+)[,\t ]*/);
         if (skipProcess) {
@@ -144,206 +136,13 @@ export default class ShaderityUtility {
           }
         }
 
-        const systemSemantic =
-          ShaderSemantics.fromStringCaseSensitively(variableName);
-        shaderSemanticsInfo.semantic = systemSemantic;
-        if (systemSemantic == null) {
-          if (existingShaderInfoMap) {
-            const semanticInfo = existingShaderInfoMap.get(variableName);
-            if (semanticInfo != null) {
-              shaderSemanticsInfo.semantic = semanticInfo.semantic;
-            } else {
-              const semantic = new ShaderSemanticsClass({str: variableName});
-              shaderSemanticsInfo.semantic = semantic;
-            }
-          } else {
-            const semantic = new ShaderSemanticsClass({str: variableName});
-            shaderSemanticsInfo.semantic = semantic;
-          }
-        }
-        shaderSemanticsInfo.componentType = ComponentType.fromGlslString(type);
-        shaderSemanticsInfo.compositionType =
-          CompositionType.fromGlslString(type);
-
-        const soloDatum = info.match(/soloDatum[\t ]*=[\t ]*(\w+)[,\t ]*/);
-        let bool = false;
-        if (soloDatum) {
-          const soloDatumText = soloDatum[1];
-          if (soloDatumText === 'true') {
-            bool = true;
-          }
-        }
-        shaderSemanticsInfo.soloDatum = bool;
-
-        const isSystem = info.match(/isSystem[\t ]*=[\t ]*(\w+)[,\t ]*/);
-        let isSystemFlg = false;
-        if (isSystem) {
-          const isSystemText = isSystem[1];
-          if (isSystemText === 'true') {
-            isSystemFlg = true;
-          }
-        }
-        shaderSemanticsInfo.isSystem = isSystemFlg;
-
-        const updateInterval = info.match(
-          /updateInterval[\t ]*=[\t ]*(\w+)[,\t ]*/
+        const shaderSemanticsInfo = this.__createShaderSemanticsInfo(
+          type,
+          variableName,
+          info,
+          existingShaderInfoMap
         );
-        let updateIntervalObj = ShaderVariableUpdateInterval.FirstTimeOnly;
-        if (updateInterval) {
-          const updateIntervalText = updateInterval[1];
-          if (updateIntervalText.toLowerCase() === 'everytime') {
-            updateIntervalObj = ShaderVariableUpdateInterval.EveryTime;
-          }
-        }
-        shaderSemanticsInfo.updateInterval = updateIntervalObj;
 
-        const initialValue = info.match(/initialValue[\t ]*=[\t ]*(.+)[,\t ]*/);
-        if (initialValue) {
-          const initialValueText = initialValue[1];
-          const tuple = initialValueText.match(/\(([\d\w., ]+)\)/);
-          const checkCompositionNumber = (expected: CompositionTypeEnum) => {
-            if (shaderSemanticsInfo.compositionType !== expected) {
-              console.error('component number of initialValue is invalid!');
-            }
-          };
-          if (tuple) {
-            const text = tuple[1];
-            const split = text.split(',');
-            switch (split.length) {
-              case 2:
-                if (
-                  shaderSemanticsInfo.compositionType ===
-                  CompositionType.Texture2D
-                ) {
-                  const color =
-                    split[1].charAt(0).toUpperCase() + split[1].slice(1);
-                  shaderSemanticsInfo.initialValue = [
-                    parseInt(split[0]),
-                    (AbstractMaterialNode as any)[`dummy${color}Texture`],
-                  ];
-                } else if (
-                  shaderSemanticsInfo.compositionType ===
-                  CompositionType.TextureCube
-                ) {
-                  const color =
-                    split[1].charAt(0).toUpperCase() + split[1].slice(1);
-                  shaderSemanticsInfo.initialValue = [
-                    parseInt(split[0]),
-                    (AbstractMaterialNode as any)[`dummy${color}CubeTexture`],
-                  ];
-                } else {
-                  checkCompositionNumber(CompositionType.Vec2);
-                  shaderSemanticsInfo.initialValue =
-                    MutableVector2.fromCopyArray([
-                      parseFloat(split[0]),
-                      parseFloat(split[1]),
-                    ]);
-                }
-                break;
-              case 3:
-                checkCompositionNumber(CompositionType.Vec3);
-                shaderSemanticsInfo.initialValue = MutableVector3.fromCopyArray(
-                  [
-                    parseFloat(split[0]),
-                    parseFloat(split[1]),
-                    parseFloat(split[2]),
-                  ]
-                );
-                break;
-              case 4:
-                checkCompositionNumber(CompositionType.Vec4);
-                shaderSemanticsInfo.initialValue = MutableVector4.fromCopyArray(
-                  [
-                    parseFloat(split[0]),
-                    parseFloat(split[1]),
-                    parseFloat(split[2]),
-                    parseFloat(split[3]),
-                  ]
-                );
-                break;
-              case 9:
-                checkCompositionNumber(CompositionType.Mat3);
-                shaderSemanticsInfo.initialValue = new MutableMatrix33(
-                  parseFloat(split[0]),
-                  parseFloat(split[1]),
-                  parseFloat(split[2]),
-                  parseFloat(split[3]),
-                  parseFloat(split[4]),
-                  parseFloat(split[5]),
-                  parseFloat(split[6]),
-                  parseFloat(split[7]),
-                  parseFloat(split[8])
-                );
-                break;
-              case 16:
-                checkCompositionNumber(CompositionType.Mat4);
-                shaderSemanticsInfo.initialValue = new MutableMatrix44(
-                  parseFloat(split[0]),
-                  parseFloat(split[1]),
-                  parseFloat(split[2]),
-                  parseFloat(split[3]),
-                  parseFloat(split[4]),
-                  parseFloat(split[5]),
-                  parseFloat(split[6]),
-                  parseFloat(split[7]),
-                  parseFloat(split[8]),
-                  parseFloat(split[9]),
-                  parseFloat(split[10]),
-                  parseFloat(split[11]),
-                  parseFloat(split[12]),
-                  parseFloat(split[13]),
-                  parseFloat(split[14]),
-                  parseFloat(split[15])
-                );
-                break;
-              default:
-                console.error('Invalid format');
-            }
-          } else {
-            checkCompositionNumber(CompositionType.Scalar);
-            shaderSemanticsInfo.initialValue = new MutableScalar(
-              parseFloat(initialValueText)
-            );
-          }
-        } else {
-          if (shaderSemanticsInfo.compositionType === CompositionType.Scalar) {
-            shaderSemanticsInfo.initialValue = new MutableScalar(0);
-          } else if (
-            shaderSemanticsInfo.compositionType === CompositionType.Vec2
-          ) {
-            shaderSemanticsInfo.initialValue = MutableVector2.zero();
-          } else if (
-            shaderSemanticsInfo.compositionType === CompositionType.Vec3
-          ) {
-            shaderSemanticsInfo.initialValue = MutableVector3.zero();
-          } else if (
-            shaderSemanticsInfo.compositionType === CompositionType.Vec4
-          ) {
-            shaderSemanticsInfo.initialValue = MutableVector4.zero();
-          } else if (
-            shaderSemanticsInfo.compositionType === CompositionType.Mat3
-          ) {
-            shaderSemanticsInfo.initialValue = MutableMatrix33.identity();
-          } else if (
-            shaderSemanticsInfo.compositionType === CompositionType.Mat4
-          ) {
-            shaderSemanticsInfo.initialValue = MutableMatrix44.identity();
-          } else if (
-            shaderSemanticsInfo.compositionType === CompositionType.Texture2D
-          ) {
-            shaderSemanticsInfo.initialValue = [
-              0,
-              AbstractMaterialNode.dummyWhiteTexture,
-            ];
-          } else if (
-            shaderSemanticsInfo.compositionType === CompositionType.TextureCube
-          ) {
-            shaderSemanticsInfo.initialValue = [
-              0,
-              AbstractMaterialNode.dummyBlackTexture,
-            ];
-          }
-        }
         shaderSemanticsInfoArray.push(shaderSemanticsInfo);
       } else {
         uniformOmittedShaderRows.push(row);
@@ -366,5 +165,207 @@ export default class ShaderityUtility {
     };
 
     return copiedObj;
+  }
+
+  private static __createShaderSemanticsInfo(
+    type: string,
+    variableName: string,
+    info: string,
+    existingShaderInfoMap?: Map<ShaderSemanticsName, ShaderSemanticsInfo>
+  ): ShaderSemanticsInfo {
+    const shaderSemanticsInfo: any = {};
+    const u_prefixedName = variableName.match(/u_(\w+)/);
+    if (u_prefixedName) {
+      variableName = u_prefixedName[1];
+      shaderSemanticsInfo.none_u_prefix = false;
+    } else {
+      shaderSemanticsInfo.none_u_prefix = true;
+    }
+
+    const systemSemantic =
+      ShaderSemantics.fromStringCaseSensitively(variableName);
+    shaderSemanticsInfo.semantic = systemSemantic;
+    if (systemSemantic == null) {
+      if (existingShaderInfoMap) {
+        const semanticInfo = existingShaderInfoMap.get(variableName);
+        if (semanticInfo != null) {
+          shaderSemanticsInfo.semantic = semanticInfo.semantic;
+        } else {
+          const semantic = new ShaderSemanticsClass({str: variableName});
+          shaderSemanticsInfo.semantic = semantic;
+        }
+      } else {
+        const semantic = new ShaderSemanticsClass({str: variableName});
+        shaderSemanticsInfo.semantic = semantic;
+      }
+    }
+    shaderSemanticsInfo.componentType = ComponentType.fromGlslString(type);
+    shaderSemanticsInfo.compositionType = CompositionType.fromGlslString(type);
+
+    const soloDatum = info.match(/soloDatum[\t ]*=[\t ]*(\w+)[,\t ]*/);
+    let bool = false;
+    if (soloDatum) {
+      const soloDatumText = soloDatum[1];
+      if (soloDatumText === 'true') {
+        bool = true;
+      }
+    }
+    shaderSemanticsInfo.soloDatum = bool;
+
+    const isSystem = info.match(/isSystem[\t ]*=[\t ]*(\w+)[,\t ]*/);
+    let isSystemFlg = false;
+    if (isSystem) {
+      const isSystemText = isSystem[1];
+      if (isSystemText === 'true') {
+        isSystemFlg = true;
+      }
+    }
+    shaderSemanticsInfo.isSystem = isSystemFlg;
+
+    const updateInterval = info.match(
+      /updateInterval[\t ]*=[\t ]*(\w+)[,\t ]*/
+    );
+    let updateIntervalObj = ShaderVariableUpdateInterval.FirstTimeOnly;
+    if (updateInterval) {
+      const updateIntervalText = updateInterval[1];
+      if (updateIntervalText.toLowerCase() === 'everytime') {
+        updateIntervalObj = ShaderVariableUpdateInterval.EveryTime;
+      }
+    }
+    shaderSemanticsInfo.updateInterval = updateIntervalObj;
+
+    const initialValue = info.match(/initialValue[\t ]*=[\t ]*(.+)[,\t ]*/);
+    if (initialValue) {
+      const initialValueText = initialValue[1];
+      const tuple = initialValueText.match(/\(([\d\w., ]+)\)/);
+      const checkCompositionNumber = (expected: CompositionTypeEnum) => {
+        if (shaderSemanticsInfo.compositionType !== expected) {
+          console.error('component number of initialValue is invalid!');
+        }
+      };
+      if (tuple) {
+        const text = tuple[1];
+        const split = text.split(',');
+        switch (split.length) {
+          case 2:
+            if (
+              shaderSemanticsInfo.compositionType === CompositionType.Texture2D
+            ) {
+              const color =
+                split[1].charAt(0).toUpperCase() + split[1].slice(1);
+              shaderSemanticsInfo.initialValue = [
+                parseInt(split[0]),
+                (AbstractMaterialNode as any)[`dummy${color}Texture`],
+              ];
+            } else if (
+              shaderSemanticsInfo.compositionType ===
+              CompositionType.TextureCube
+            ) {
+              const color =
+                split[1].charAt(0).toUpperCase() + split[1].slice(1);
+              shaderSemanticsInfo.initialValue = [
+                parseInt(split[0]),
+                (AbstractMaterialNode as any)[`dummy${color}CubeTexture`],
+              ];
+            } else {
+              checkCompositionNumber(CompositionType.Vec2);
+              shaderSemanticsInfo.initialValue = MutableVector2.fromCopyArray([
+                parseFloat(split[0]),
+                parseFloat(split[1]),
+              ]);
+            }
+            break;
+          case 3:
+            checkCompositionNumber(CompositionType.Vec3);
+            shaderSemanticsInfo.initialValue = MutableVector3.fromCopyArray([
+              parseFloat(split[0]),
+              parseFloat(split[1]),
+              parseFloat(split[2]),
+            ]);
+            break;
+          case 4:
+            checkCompositionNumber(CompositionType.Vec4);
+            shaderSemanticsInfo.initialValue = MutableVector4.fromCopyArray([
+              parseFloat(split[0]),
+              parseFloat(split[1]),
+              parseFloat(split[2]),
+              parseFloat(split[3]),
+            ]);
+            break;
+          case 9:
+            checkCompositionNumber(CompositionType.Mat3);
+            shaderSemanticsInfo.initialValue = new MutableMatrix33(
+              parseFloat(split[0]),
+              parseFloat(split[1]),
+              parseFloat(split[2]),
+              parseFloat(split[3]),
+              parseFloat(split[4]),
+              parseFloat(split[5]),
+              parseFloat(split[6]),
+              parseFloat(split[7]),
+              parseFloat(split[8])
+            );
+            break;
+          case 16:
+            checkCompositionNumber(CompositionType.Mat4);
+            shaderSemanticsInfo.initialValue = new MutableMatrix44(
+              parseFloat(split[0]),
+              parseFloat(split[1]),
+              parseFloat(split[2]),
+              parseFloat(split[3]),
+              parseFloat(split[4]),
+              parseFloat(split[5]),
+              parseFloat(split[6]),
+              parseFloat(split[7]),
+              parseFloat(split[8]),
+              parseFloat(split[9]),
+              parseFloat(split[10]),
+              parseFloat(split[11]),
+              parseFloat(split[12]),
+              parseFloat(split[13]),
+              parseFloat(split[14]),
+              parseFloat(split[15])
+            );
+            break;
+          default:
+            console.error('Invalid format');
+        }
+      } else {
+        checkCompositionNumber(CompositionType.Scalar);
+        shaderSemanticsInfo.initialValue = new MutableScalar(
+          parseFloat(initialValueText)
+        );
+      }
+    } else {
+      if (shaderSemanticsInfo.compositionType === CompositionType.Scalar) {
+        shaderSemanticsInfo.initialValue = new MutableScalar(0);
+      } else if (shaderSemanticsInfo.compositionType === CompositionType.Vec2) {
+        shaderSemanticsInfo.initialValue = MutableVector2.zero();
+      } else if (shaderSemanticsInfo.compositionType === CompositionType.Vec3) {
+        shaderSemanticsInfo.initialValue = MutableVector3.zero();
+      } else if (shaderSemanticsInfo.compositionType === CompositionType.Vec4) {
+        shaderSemanticsInfo.initialValue = MutableVector4.zero();
+      } else if (shaderSemanticsInfo.compositionType === CompositionType.Mat3) {
+        shaderSemanticsInfo.initialValue = MutableMatrix33.identity();
+      } else if (shaderSemanticsInfo.compositionType === CompositionType.Mat4) {
+        shaderSemanticsInfo.initialValue = MutableMatrix44.identity();
+      } else if (
+        shaderSemanticsInfo.compositionType === CompositionType.Texture2D
+      ) {
+        shaderSemanticsInfo.initialValue = [
+          0,
+          AbstractMaterialNode.dummyWhiteTexture,
+        ];
+      } else if (
+        shaderSemanticsInfo.compositionType === CompositionType.TextureCube
+      ) {
+        shaderSemanticsInfo.initialValue = [
+          0,
+          AbstractMaterialNode.dummyBlackTexture,
+        ];
+      }
+    }
+
+    return shaderSemanticsInfo;
   }
 }


### PR DESCRIPTION
The getShaderDataRefection method in shaderity utility is too long. I separate the method into small parts.

Furthermore, I removed an 'any type' object.