### PR TITLE
feat: export max skeletal bone number for uniform mode option

### DIFF
--- a/src/foundation/core/Config.ts
+++ b/src/foundation/core/Config.ts
@@ -37,6 +37,7 @@ export default {
   maxCameraNumber,
   maxSizeLimitOfNonCompressedTexture,
   maxSkeletalBoneNumber,
+  maxSkeletalBoneNumberForUniformMode,
   dataTextureWidth,
   dataTextureHeight,
   noWebGLTex2DStateCache,


### PR DESCRIPTION
We cannot change maxSkeletalBoneNumberForUniformMode option now.
However, we need to change this option when the model that we want to display has more than 50 skeletal bones.
So I export this option