### PR TITLE
refactor: optimize color calculations in MToon0xSingleShader

### DIFF
--- a/src/webgl/shaderity_shaders/MToon0xSingleShader/MToon0xSingleShader.frag.glsl
+++ b/src/webgl/shaderity_shaders/MToon0xSingleShader/MToon0xSingleShader.frag.glsl
@@ -142,12 +142,9 @@ void main (){
   float lightColorAttenuation = get_lightColorAttenuation(materialSID, 0);
 
   vec3 shadeColorFactor = get_shadeColor(materialSID, 0);
-  vec3 shadeColor = shadeColorFactor * texture(u_shadeColorTexture, mainUv).xyz;
-  shadeColor.xyz = srgbToLinear(shadeColor.xyz);
+  vec3 shadeColor = shadeColorFactor * srgbToLinear(texture(u_shadeColorTexture, mainUv).xyz);
 
-  vec3 litColor = litColorFactor.xyz * litTextureColor.xyz;
-  litColor.xyz = srgbToLinear(litColor.xyz);
-
+  vec3 litColor = litColorFactor.xyz * srgbToLinear(litTextureColor.xyz);
 
   float shadeShift = get_shadeShift(materialSID, 0);
   float shadeToony = get_shadeToony(materialSID, 0);
@@ -230,7 +227,7 @@ void main (){
   #ifdef RN_MTOON_IS_OUTLINE
     #ifdef RN_MTOON_OUTLINE_COLOR_MIXED
       vec3 outlineColor = get_outlineColor(materialSID, 0);
-      outlineColor = srgbToLinear(outlineColor);
+      // outlineColor = srgbToLinear(outlineColor);
       float outlineLightingMix = get_outlineLightingMix(materialSID, 0);
       rt0.xyz = outlineColor * mix(vec3(1.0), rt0.xyz, outlineLightingMix);
     #endif
@@ -239,7 +236,7 @@ void main (){
     float rimLift = get_rimLift(materialSID, 0);
     vec3 rimColorFactor = get_rimColor(materialSID, 0);
     vec3 rimTextureColor = texture(u_rimTexture, mainUv).xyz;
-    vec3 rimColor = srgbToLinear(rimColorFactor * rimTextureColor);
+    vec3 rimColor = rimColorFactor * srgbToLinear(rimTextureColor);
     vec3 rim = pow(clamp(1.0 - dot(normal_inWorld, viewDirection) + rimLift, 0.0, 1.0), rimFresnelPower) * rimColor;
 
     float staticRimLighting = 1.0;

--- a/src/webgpu/shaderity_shaders/MToon0xSingleShader/MToon0xSingleShader.frag.wgsl
+++ b/src/webgpu/shaderity_shaders/MToon0xSingleShader/MToon0xSingleShader.frag.wgsl
@@ -129,12 +129,9 @@ fn main (
   let lightColorAttenuation: f32 = get_lightColorAttenuation(materialSID, 0);
 
   let shadeColorFactor: vec3f = get_shadeColor(materialSID, 0);
-  var shadeColor: vec3f = shadeColorFactor * textureSample(shadeColorTexture, shadeColorSampler, mainUv).xyz;
-  shadeColor = srgbToLinear(shadeColor.xyz);
+  var shadeColor: vec3f = shadeColorFactor * srgbToLinear(textureSample(shadeColorTexture, shadeColorSampler, mainUv).xyz);
 
-  var litColor: vec3f = litColorFactor.xyz * litTextureColor.xyz;
-  litColor = srgbToLinear(litColor.xyz);
-
+  var litColor: vec3f = litColorFactor.xyz * srgbToLinear(litTextureColor.xyz);
 
   let shadeShift: f32 = get_shadeShift(materialSID, 0);
   let shadeToony: f32 = get_shadeToony(materialSID, 0);
@@ -217,7 +214,7 @@ fn main (
   #ifdef RN_MTOON_IS_OUTLINE
     #ifdef RN_MTOON_OUTLINE_COLOR_MIXED
       var outlineColor: vec3f = get_outlineColor(materialSID, 0);
-      outlineColor = srgbToLinear(outlineColor);
+      // outlineColor = srgbToLinear(outlineColor);
       let outlineLightingMix: f32 = get_outlineLightingMix(materialSID, 0);
       rt0 = vec4f(outlineColor * mix(vec3f(1.0), rt0.xyz, outlineLightingMix), rt0.w);
     #endif
@@ -226,7 +223,7 @@ fn main (
     let rimLift: f32 = get_rimLift(materialSID, 0);
     let rimColorFactor: vec3f = get_rimColor(materialSID, 0);
     let rimTextureColor: vec3f = textureSample(rimTexture, rimSampler, mainUv).xyz;
-    let rimColor: vec3f = srgbToLinear(rimColorFactor * rimTextureColor);
+    let rimColor: vec3f = rimColorFactor * srgbToLinear(rimTextureColor);
     let rim: vec3f = pow(clamp(1.0 - dot(normal_inWorld, viewDirection) + rimLift, 0.0, 1.0), rimFresnelPower) * rimColor;
 
     var staticRimLighting = 1.0;


### PR DESCRIPTION
- Simplified shade color and lit color calculations by integrating the srgbToLinear conversion directly into the texture sampling process.
- Removed redundant srgbToLinear calls for outline color, improving clarity in the shader code.
- Enhanced readability and maintainability of the shader code by streamlining color processing logic.