### PR TITLE
feat: update AABBGizmo to ensure proper initialization

### DIFF
--- a/src/foundation/gizmos/AABBGizmo.ts
+++ b/src/foundation/gizmos/AABBGizmo.ts
@@ -62,6 +62,8 @@ export class AABBGizmo extends Gizmo {
     meshComponent.setMesh(AABBGizmo.__mesh);
 
     this.setGizmoTag();
+
+    this._update();
   }
 
   /**


### PR DESCRIPTION
- Added a call to `_update()` in the `AABBGizmo` class after setting the mesh component, ensuring that the gizmo is correctly initialized and updated with the latest mesh data.