### PR TITLE
fix: set unique name when cloning in Expression and RenderPass classes

### DIFF
--- a/src/foundation/renderer/Expression.ts
+++ b/src/foundation/renderer/Expression.ts
@@ -14,6 +14,7 @@ export class Expression extends RnObject {
 
   clone() {
     const exp = new Expression();
+    exp.tryToSetUniqueName(this.uniqueName + '_cloned', true);
     const renderPasses = [];
     for (const renderPass of this.__renderPasses) {
       renderPasses.push(renderPass.clone());

--- a/src/foundation/renderer/RenderPass.ts
+++ b/src/foundation/renderer/RenderPass.ts
@@ -144,6 +144,7 @@ export class RenderPass extends RnObject {
 
   clone() {
     const renderPass = new RenderPass();
+    renderPass.tryToSetUniqueName(this.uniqueName + '_cloned', true);
     renderPass.__entities = this.__entities.concat();
     renderPass.__sceneGraphDirectlyAdded = this.__sceneGraphDirectlyAdded.concat();
     renderPass.__topLevelSceneGraphComponents = this.__topLevelSceneGraphComponents.concat();


### PR DESCRIPTION
- Added a call to `tryToSetUniqueName` in the `clone` method of both `Expression` and `RenderPass` classes to ensure that cloned instances have unique names, improving object management and preventing naming conflicts.