### PR TITLE
fix: comment out unnecessary framebuffer clearing in ForwardRend…

### DIFF
--- a/src/foundation/renderer/pipelines/ForwardRenderPipeline.ts
+++ b/src/foundation/renderer/pipelines/ForwardRenderPipeline.ts
@@ -325,8 +325,8 @@ export class ForwardRenderPipeline extends RnObject {
         renderPass.setFramebuffer(this.__oFrameDepthMoment.unwrapForce());
         renderPass.setResolveFramebuffer(undefined);
         renderPass.setResolveFramebuffer2(undefined);
-        renderPass.toClearColorBuffer = true;
-        renderPass.toClearDepthBuffer = true;
+        // renderPass.toClearColorBuffer = true;
+        // renderPass.toClearDepthBuffer = true;
         // No need to render transparent primitives to depth buffer.
         renderPass.setToRenderTransparentPrimitives(false);
 


### PR DESCRIPTION
…erPipeline

- Removed the default clearing of color and depth buffers in the ForwardRenderPipeline, as it is no longer needed for rendering transparent primitives. This change simplifies the rendering process and may improve performance.