### PR TITLE
feat: enhance mesh and render pass handling for primitive types

### DIFF
--- a/src/foundation/renderer/RenderPass.ts
+++ b/src/foundation/renderer/RenderPass.ts
@@ -81,8 +81,14 @@ export class RenderPass extends RnObject {
   /** Whether or not to draw opaque primitives contained in this render pass. */
   public _toRenderOpaquePrimitives = true;
 
-  /** Whether or not to draw transparent primitives contained in this render pass. */
-  public _toRenderTransparentPrimitives = true;
+  /** Whether or not to draw translucent primitives contained in this render pass. */
+  public _toRenderTranslucentPrimitives = true;
+
+  /** Whether or not to draw blend with ZWrite primitives contained in this render pass. */
+  public _toRenderBlendWithZWritePrimitives = true;
+
+  /** Whether or not to draw blend without ZWrite primitives contained in this render pass. */
+  public _toRenderBlendWithoutZWritePrimitives = true;
 
   public toRenderEffekseerEffects = false;
   public __renderTargetColorAttachments?: RenderBufferTargetEnum[];
@@ -101,8 +107,18 @@ export class RenderPass extends RnObject {
     this.__calcMeshComponents();
   }
 
-  setToRenderTransparentPrimitives(toRender: boolean) {
-    this._toRenderTransparentPrimitives = toRender;
+  setToRenderBlendWithoutZWritePrimitives(toRender: boolean) {
+    this._toRenderBlendWithoutZWritePrimitives = toRender;
+    this.__calcMeshComponents();
+  }
+
+  setToRenderBlendWithZWritePrimitives(toRender: boolean) {
+    this._toRenderBlendWithZWritePrimitives = toRender;
+    this.__calcMeshComponents();
+  }
+
+  setToRenderTranslucentPrimitives(toRender: boolean) {
+    this._toRenderTranslucentPrimitives = toRender;
     this.__calcMeshComponents();
   }
 
@@ -167,7 +183,8 @@ export class RenderPass extends RnObject {
     renderPass.isVrRendering = this.isVrRendering;
     renderPass.isOutputForVr = this.isOutputForVr;
     renderPass._toRenderOpaquePrimitives = this._toRenderOpaquePrimitives;
-    renderPass._toRenderTransparentPrimitives = this._toRenderTransparentPrimitives;
+    renderPass._toRenderTranslucentPrimitives = this._toRenderTranslucentPrimitives;
+    renderPass._toRenderBlendWithoutZWritePrimitives = this._toRenderBlendWithoutZWritePrimitives;
     renderPass.__postEachRenderFunc = this.__postEachRenderFunc;
     renderPass.__renderTargetColorAttachments = this.__renderTargetColorAttachments?.concat();
     renderPass._lastOpaqueIndex = this._lastOpaqueIndex;
@@ -279,10 +296,23 @@ export class RenderPass extends RnObject {
       ) as MeshComponent | undefined;
       if (meshComponent != null && meshComponent.mesh != null) {
         this.__meshComponents!.push(meshComponent);
-        if (!this._toRenderOpaquePrimitives && meshComponent.mesh.isAllOpaque()) {
+        if (!this._toRenderOpaquePrimitives && meshComponent.mesh.isExistOpaque()) {
           return;
         }
-        if (!this._toRenderTransparentPrimitives && meshComponent.mesh.isAllTranslucent()) {
+
+        if (!this._toRenderTranslucentPrimitives && meshComponent.mesh.isExistTranslucent()) {
+          return;
+        }
+        if (
+          !this._toRenderBlendWithZWritePrimitives &&
+          meshComponent.mesh.isExistBlendWithZWrite()
+        ) {
+          return;
+        }
+        if (
+          !this._toRenderBlendWithoutZWritePrimitives &&
+          meshComponent.mesh.isExistBlendWithoutZWrite()
+        ) {
           return;
         }
         this.__optimizedMeshComponents!.push(meshComponent);

--- a/src/foundation/renderer/pipelines/ForwardRenderPipeline.ts
+++ b/src/foundation/renderer/pipelines/ForwardRenderPipeline.ts
@@ -329,10 +329,10 @@ export class ForwardRenderPipeline extends RnObject {
         renderPass.setFramebuffer(this.__oFrameDepthMoment.unwrapForce());
         renderPass.setResolveFramebuffer(undefined);
         renderPass.setResolveFramebuffer2(undefined);
-        // renderPass.toClearColorBuffer = true;
-        // renderPass.toClearDepthBuffer = true;
-        // No need to render transparent primitives to depth buffer.
-        renderPass.setToRenderTransparentPrimitives(false);
+        renderPass.setToRenderOpaquePrimitives(true);
+        renderPass.setToRenderTranslucentPrimitives(true);
+        renderPass.setToRenderBlendWithZWritePrimitives(true);
+        renderPass.setToRenderBlendWithoutZWritePrimitives(false);
 
         renderPass.setMaterial(depthMomentMaterial);
       }
@@ -573,14 +573,16 @@ export class ForwardRenderPipeline extends RnObject {
     for (const expression of expressions) {
       for (const rp of expression.renderPasses) {
         rp.setToRenderOpaquePrimitives(true);
+        rp.setToRenderBlendWithZWritePrimitives(true);
+        rp.setToRenderBlendWithoutZWritePrimitives(true);
         if (options.isTransmission) {
           // if options.isTransmission is true, set toRenderTransparentPrimitives to false,
           // because transparent primitives are rendered in later expression.
-          rp.setToRenderTransparentPrimitives(false);
+          rp.setToRenderTranslucentPrimitives(false);
         } else {
           // if options.isTransmission is false, set toRenderTransparentPrimitives to true.
           // because transparent primitives are rendered in this expression as well as opaque primitives.
-          rp.setToRenderTransparentPrimitives(true);
+          rp.setToRenderTranslucentPrimitives(true);
         }
 
         // clearing depth is done in initial expression. so no need to clear depth in this render pass.
@@ -606,7 +608,9 @@ export class ForwardRenderPipeline extends RnObject {
       expression.tryToSetUniqueName('modelTransparentForTransmission', true);
       for (const rp of expression.renderPasses) {
         rp.setToRenderOpaquePrimitives(false); // not to render opaque primitives in transmission expression.
-        rp.setToRenderTransparentPrimitives(true);
+        rp.setToRenderTranslucentPrimitives(true);
+        rp.setToRenderBlendWithZWritePrimitives(false);
+        rp.setToRenderBlendWithoutZWritePrimitives(false);
         rp.toClearDepthBuffer = false;
         // rp.isDepthTest = false;
         // rp.depthWriteMask = false;

--- a/src/webgl/WebGLStrategyDataTexture.ts
+++ b/src/webgl/WebGLStrategyDataTexture.ts
@@ -759,14 +759,16 @@ ${returnType} get_${methodName}(highp float _instanceId, const int idxOfArray) {
       }
     }
 
-    if (renderPass._toRenderTransparentPrimitives) {
+    if (renderPass._toRenderTranslucentPrimitives) {
       // Draw Translucent primitives
       for (let i = renderPass._lastOpaqueIndex + 1; i <= renderPass._lastTranslucentIndex; i++) {
         const primitiveUid = primitiveUids[i];
         const rendered = this.__renderInner(primitiveUid, glw, renderPass);
         renderedSomething ||= rendered;
       }
+    }
 
+    if (renderPass._toRenderBlendWithZWritePrimitives) {
       // Draw Blend primitives with ZWrite
       for (
         let i = renderPass._lastTranslucentIndex + 1;
@@ -777,7 +779,9 @@ ${returnType} get_${methodName}(highp float _instanceId, const int idxOfArray) {
         const rendered = this.__renderInner(primitiveUid, glw, renderPass);
         renderedSomething ||= rendered;
       }
+    }
 
+    if (renderPass._toRenderBlendWithoutZWritePrimitives) {
       if (!MeshRendererComponent.isDepthMaskTrueForBlendPrimitives) {
         // disable depth write for blend primitives
         gl.depthMask(false);

--- a/src/webgl/WebGLStrategyUniform.ts
+++ b/src/webgl/WebGLStrategyUniform.ts
@@ -396,15 +396,17 @@ bool get_isBillboard(float instanceId) {
     }
 
     // For translucent primitives
-    if (renderPass._toRenderTransparentPrimitives) {
+    if (renderPass._toRenderTranslucentPrimitives) {
       // Draw Translucent primitives
       for (let i = renderPass._lastOpaqueIndex + 1; i <= renderPass._lastTranslucentIndex; i++) {
         const primitiveUid = primitiveUids[i];
         const rendered = this.renderInner(primitiveUid, glw, renderPass, renderPassTickCount);
         renderedSomething ||= rendered;
       }
+    }
 
-      // Draw Blend primitives with ZWrite
+    // Draw Blend primitives with ZWrite
+    if (renderPass._toRenderBlendWithZWritePrimitives) {
       for (
         let i = renderPass._lastTranslucentIndex + 1;
         i <= renderPass._lastBlendWithZWriteIndex;
@@ -414,7 +416,9 @@ bool get_isBillboard(float instanceId) {
         const rendered = this.renderInner(primitiveUid, glw, renderPass, renderPassTickCount);
         renderedSomething ||= rendered;
       }
+    }
 
+    if (renderPass._toRenderBlendWithoutZWritePrimitives) {
       if (!MeshRendererComponent.isDepthMaskTrueForBlendPrimitives) {
         // disable depth write for blend primitives
         gl.depthMask(false);

--- a/src/webgpu/WebGpuStrategyBasic.ts
+++ b/src/webgpu/WebGpuStrategyBasic.ts
@@ -427,14 +427,16 @@ ${indexStr}
     }
 
     // For translucent primitives
-    if (renderPass._toRenderTransparentPrimitives) {
+    if (renderPass._toRenderTranslucentPrimitives) {
       // Draw Translucent primitives
       for (let i = renderPass._lastOpaqueIndex + 1; i <= renderPass._lastTranslucentIndex; i++) {
         const primitiveUid = primitiveUids[i];
         const rendered = this.renderInner(primitiveUid, renderPass, isZWrite);
         renderedSomething ||= rendered;
       }
+    }
 
+    if (renderPass._toRenderBlendWithZWritePrimitives) {
       // Draw Blend primitives with ZWrite
       for (
         let i = renderPass._lastTranslucentIndex + 1;
@@ -445,7 +447,9 @@ ${indexStr}
         const rendered = this.renderInner(primitiveUid, renderPass, isZWrite);
         renderedSomething ||= rendered;
       }
+    }
 
+    if (renderPass._toRenderBlendWithoutZWritePrimitives) {
       // Draw Blend primitives without ZWrite
       for (
         let i = renderPass._lastBlendWithZWriteIndex + 1;


### PR DESCRIPTION
- Updated the Mesh class to categorize primitives into opaque, translucent, blend with ZWrite, and blend without ZWrite, improving rendering logic.
- Modified RenderPass to manage rendering flags for translucent and blend primitives, replacing the previous transparent primitive handling.
- Adjusted ForwardRenderPipeline to set appropriate rendering flags for different primitive types, ensuring correct rendering behavior.
- Updated WebGL and WebGPU strategies to reflect changes in primitive rendering logic, enhancing overall rendering performance and flexibility.