### PR TITLE
fix: remove unnecessary call to setWorldMatrixDirty in VRMSpringBoneP…

### DIFF
--- a/src/foundation/physics/VRMSpring/VRMSpringBonePhysicsStrategy.ts
+++ b/src/foundation/physics/VRMSpring/VRMSpringBonePhysicsStrategy.ts
@@ -158,7 +158,6 @@ export class VRMSpringBonePhysicsStrategy implements PhysicsStrategy {
 
     bone.node.localRotation = resultRotation;
     bone.node.getSceneGraph().setWorldMatrixDirty();
-    center?.setWorldMatrixDirty();
   }
 
   normalizeBoneLength(nextTail: Vector3, bone: VRMSpringBone) {


### PR DESCRIPTION
…hysicsStrategy

- Eliminated the redundant call to center?.setWorldMatrixDirty() in the VRMSpringBonePhysicsStrategy class, streamlining the bone physics calculations and improving code clarity.