### PR TITLE
fix: update devcontainer for 2025h1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/typescript-node/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/devcontainers/images/blob/v0.4.15/src/typescript-node/.devcontainer/Dockerfile
 
-# [Choice] Node.js version: 16, 14, 12
-ARG VARIANT="16-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}
+# [Choice] Node.js version: 22, 20, 18
+ARG VARIANT="22-bookworm"
+FROM mcr.microsoft.com/devcontainers/typescript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
@@ -20,11 +20,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
   unzip \
   wget \
   chromium \
-&& rm -rf /var/lib/apt/lists/* \
-&& ln -s /usr/bin/chromium /usr/bin/chromium-browser \
-&& echo "progress = dot:giga" | tee /etc/wgetrc \
-&& mkdir -p /mnt /opt /data \
-&& wget https://github.com/andmarios/duphard/releases/download/v1.0/duphard -O /bin/duphard \
-&& chmod +x /bin/duphard
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -s /usr/bin/chromium /usr/bin/chromium-browser \
+  && echo "progress = dot:giga" | tee /etc/wgetrc \
+  && mkdir -p /mnt /opt /data \
+  && wget https://github.com/andmarios/duphard/releases/download/v1.0/duphard -O /bin/duphard \
+  && chmod +x /bin/duphard
 RUN su node -c "npm install -g yarn"
 RUN yarn install

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,25 +1,25 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/typescript-node
+// https://github.com/devcontainers/images/tree/v0.4.15/src/typescript-node
 {
 	"name": "RhodoniteTS devContainer",
 	"dockerComposeFile": "./docker-compose.yml",
 	"workspaceFolder": "/node",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
 	"service": "node",
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint",
-		"editorconfig.editorconfig"
-	],
-
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"editorconfig.editorconfig"
+			]
+		}
+	}
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
-
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "node"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - VARIANT=16-bullseye
+        - VARIANT=22-bookworm
     working_dir: /node
     volumes:
       - type: bind


### PR DESCRIPTION
Since the initial release, new versions made substantial changes to dev containers. This commit upgrades the versions to the latest LTS, updates JSON according to the latest scheme, and fixes comment lines with active links.