### PR TITLE
chore: Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ yarn test
 ```
 
 You can also run only unit tests or a subset of the E2E tests using the commands described in the [README](README.md).
+The E2E test will only pass if the test is run in the library author's environment, so you can submit a PR in a failed state.
 
 ## Submitting pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to Rhodonite
+
+Thank you for considering contributing to Rhodonite! This document describes how to set up your environment, run the tests and send pull requests.
+
+## Project setup
+
+1. Install **Node.js 22** or later and **yarn**.
+2. Clone the repository and fetch submodules:
+
+```bash
+git clone https://github.com/actnwit/RhodoniteTS.git
+cd RhodoniteTS
+git submodule update --init
+```
+
+3. Install the dependencies:
+
+```bash
+yarn install
+```
+
+## Running tests
+
+Before opening a pull request please make sure that the build and all tests succeed.
+
+```bash
+yarn build
+yarn build-samples
+yarn test
+```
+
+You can also run only unit tests or a subset of the E2E tests using the commands described in the [README](README.md).
+
+## Submitting pull requests
+
+1. Fork the repository and create a new branch for your work.
+2. Ensure `yarn build` and `yarn test` run without errors.
+3. Push your branch and open a pull request against the **main** branch of this repository.
+4. Provide a clear description of your changes.
+
+We appreciate your contributions!

--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ After a new dev container window opens, You can work in the Debian Linux contain
 3. Push the run icon by choosing "Launch Chrome to debug Rhodonite samples" in the RUN tab of VSCode's left pane to start debugging.
 
 If you use the VSCode devcontainer environment, You should open another RhodoniteTS VSCode window locally and do debug ops on it instead of the devcontainer VSCode window.
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on setting up the project, running tests and submitting pull requests.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -244,10 +244,10 @@ After a new dev container window opens, You can work in the Debian Linux contain
 3. Push the run icon by choosing "Launch Chrome to debug Rhodonite samples" in the RUN tab of VSCode's left pane to start debugging.
 
 If you use the VSCode devcontainer environment, You should open another RhodoniteTS VSCode window locally and do debug ops on it instead of the devcontainer VSCode window.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on setting up the project, running tests and submitting pull requests.
-
 
 ## License
 


### PR DESCRIPTION
## Summary
- add contributing instructions for setup, testing and PR flow
- link to the contributing guide from README

## Testing
- `yarn install` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_6842c02a2eb4832492544810c43ab95c