### PR TITLE
fix: InputManager error message capitalization

### DIFF
--- a/src/foundation/system/InputManager.ts
+++ b/src/foundation/system/InputManager.ts
@@ -63,7 +63,7 @@ declare global {
  */
 export function getEvent(type: 'start' | 'move' | 'end' | 'click'): string {
   if (typeof window === "undefined") {
-    throw new Error("THis function works in Browser environment")
+    throw new Error("This function works in Browser environment")
   }
   const deviceEvents = {
     Touch: typeof document.ontouchstart !== 'undefined',


### PR DESCRIPTION
## Summary
- fix capitalization in InputManager error message

## Testing
- `npm test` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6842dd84c0d08324b30f150bb76ccab4