### PR TITLE
feat: add support for KHR_materials_anisotropy extension in Gltf2Expo…

### DIFF
--- a/src/foundation/exporter/Gltf2Exporter.ts
+++ b/src/foundation/exporter/Gltf2Exporter.ts
@@ -1544,10 +1544,8 @@ export class Gltf2Exporter {
     const shouldAttachAnisotropyExtension =
       anisotropyExtensionUsed ||
       Is.exist(anisotropyExtension.anisotropyTexture) ||
-      (Is.exist(anisotropyExtension.anisotropyStrength) &&
-        (anisotropyExtension.anisotropyStrength as number) !== 0) ||
-      (Is.exist(anisotropyExtension.anisotropyRotation) &&
-        (anisotropyExtension.anisotropyRotation as number) !== 0);
+      (Is.exist(anisotropyExtension.anisotropyStrength) && (anisotropyExtension.anisotropyStrength as number) !== 0) ||
+      (Is.exist(anisotropyExtension.anisotropyRotation) && (anisotropyExtension.anisotropyRotation as number) !== 0);
     if (shouldAttachAnisotropyExtension) {
       material.extensions = material.extensions ?? {};
       material.extensions.KHR_materials_anisotropy = anisotropyExtension;


### PR DESCRIPTION
…rter

- Implemented handling for the KHR_materials_anisotropy extension, allowing the export of anisotropy properties such as texture and strength.
- Introduced a new private method to manage anisotropy extension logic, ensuring proper integration with existing material attributes.
- Enhanced material processing to include anisotropy properties, improving the fidelity of exported materials in glTF files.