### PR TITLE
feat: enhance texture handling by introducing dummy texture support

### DIFF
--- a/src/foundation/exporter/Gltf2Exporter.ts
+++ b/src/foundation/exporter/Gltf2Exporter.ts
@@ -883,7 +883,7 @@ export class Gltf2Exporter {
     };
 
     const processTexture = (rnTexture: AbstractTexture, rnSampler?: Sampler) => {
-      if (rnTexture && rnTexture.width > 1 && rnTexture.height > 1) {
+      if (rnTexture?.isTextureReady && !rnTexture.isDummyTexture && rnTexture.width >= 1 && rnTexture.height >= 1) {
         const samplerIdx = processSampler(rnSampler);
         const imageIndex = processImage(rnTexture);
 

--- a/src/foundation/importer/Vrm0xImporter.ts
+++ b/src/foundation/importer/Vrm0xImporter.ts
@@ -346,9 +346,11 @@ export class Vrm0xImporter {
 
     const dummyWhiteTexture = new Texture();
     await dummyWhiteTexture.generate1x1TextureFrom();
+    dummyWhiteTexture.markAsDummyTexture();
     rnTextures.push(dummyWhiteTexture);
     const dummyBlackTexture = new Texture();
     await dummyBlackTexture.generate1x1TextureFrom('rgba(0, 0, 0, 1)');
+    dummyBlackTexture.markAsDummyTexture();
     rnTextures.push(dummyBlackTexture);
 
     return rnTextures;

--- a/src/foundation/importer/VrmImporter.ts
+++ b/src/foundation/importer/VrmImporter.ts
@@ -356,9 +356,11 @@ export class VrmImporter {
 
     const dummyWhiteTexture = new Texture();
     await dummyWhiteTexture.generate1x1TextureFrom();
+    dummyWhiteTexture.markAsDummyTexture();
     rnTextures.push(dummyWhiteTexture);
     const dummyBlackTexture = new Texture();
     await dummyBlackTexture.generate1x1TextureFrom('rgba(0, 0, 0, 1)');
+    dummyBlackTexture.markAsDummyTexture();
     rnTextures.push(dummyBlackTexture);
 
     return rnTextures;

--- a/src/foundation/materials/core/DummyTextures.ts
+++ b/src/foundation/materials/core/DummyTextures.ts
@@ -80,14 +80,22 @@ export async function initDefaultTextures() {
   dummyDepthMomentTextureArray.tryToSetUniqueName('dummyDepthMomentTextureArray', true);
 
   await dummyWhiteTexture.generate1x1TextureFrom();
+  dummyWhiteTexture.markAsDummyTexture();
   await dummyBlueTexture.generate1x1TextureFrom('rgba(127.5, 127.5, 255, 1)');
+  dummyBlueTexture.markAsDummyTexture();
   await dummyBlackTexture.generate1x1TextureFrom('rgba(0, 0, 0, 1)');
+  dummyBlackTexture.markAsDummyTexture();
   dummyBlackCubeTexture.load1x1Texture('rgba(0, 0, 0, 1)');
+  dummyBlackCubeTexture.markAsDummyTexture();
   dummyZeroTexture.generate1x1TextureFrom('rgba(0, 0, 0, 0)');
+  dummyZeroTexture.markAsDummyTexture();
   await sheenLutTexture.generateSheenLutTextureFromDataUri();
   await dummySRGBGrayTexture.generate1x1TextureFrom('rgba(186, 186, 186, 1)');
+  dummySRGBGrayTexture.markAsDummyTexture();
   await dummyAnisotropyTexture.generate1x1TextureFrom('rgba(255, 127.5, 255, 1)');
+  dummyAnisotropyTexture.markAsDummyTexture();
   dummyDepthMomentTextureArray.load1x1Texture('rgba(255, 255, 255, 1)');
+  dummyDepthMomentTextureArray.markAsDummyTexture();
 }
 
 /**

--- a/src/foundation/textures/AbstractTexture.ts
+++ b/src/foundation/textures/AbstractTexture.ts
@@ -32,6 +32,7 @@ export abstract class AbstractTexture extends RnObject {
   protected __type: ComponentTypeEnum = ComponentType.UnsignedByte;
 
   protected __hasTransparentPixels = false;
+  protected __isDummyTexture = false;
 
   private static readonly InvalidTextureUid: TextureUID = -1;
   private static __textureUidCount: TextureUID = AbstractTexture.InvalidTextureUid;
@@ -140,6 +141,24 @@ export abstract class AbstractTexture extends RnObject {
    */
   get startedToLoad() {
     return this.__startedToLoad;
+  }
+
+  /**
+   * Checks whether this texture is marked as a dummy (placeholder) texture.
+   *
+   * @returns True if the texture is marked as dummy, false otherwise
+   */
+  get isDummyTexture() {
+    return this.__isDummyTexture;
+  }
+
+  /**
+   * Marks this texture as a dummy (placeholder) texture.
+   *
+   * @param isDummy - Whether to mark the texture as dummy (default: true)
+   */
+  markAsDummyTexture(isDummy = true) {
+    this.__isDummyTexture = isDummy;
   }
 
   /**


### PR DESCRIPTION
- Updated Gltf2Exporter to check for dummy textures during processing, improving texture validation.
- Added functionality to mark textures as dummy in Vrm0xImporter and VrmImporter, ensuring proper handling of placeholder textures.
- Enhanced the AbstractTexture class with methods to manage dummy texture states, promoting better texture management across the codebase.