### PR TITLE
feat: add KHR_materials_iridescence support in Gltf2Exporter and …

### DIFF
--- a/src/foundation/exporter/Gltf2Exporter.ts
+++ b/src/foundation/exporter/Gltf2Exporter.ts
@@ -44,6 +44,7 @@ import {
   __outputKhrMaterialsAnisotropyInfo,
   __outputKhrMaterialsClearcoatInfo,
   __outputKhrMaterialsIorInfo,
+  __outputKhrMaterialsIridescenceInfo,
   __outputKhrMaterialsSheenInfo,
   __outputKhrMaterialsTransmissionInfo,
   __outputKhrMaterialsVolumeInfo,
@@ -884,6 +885,8 @@ export class Gltf2Exporter {
     __outputKhrMaterialsVolumeInfo(ensureExtensionUsed, coerceNumber, coerceVec3, rnMaterial, applyTexture, material);
 
     __outputKhrMaterialsIorInfo(ensureExtensionUsed, coerceNumber, rnMaterial, material);
+
+    __outputKhrMaterialsIridescenceInfo(ensureExtensionUsed, coerceNumber, rnMaterial, applyTexture, material);
 
     __outputKhrMaterialsClearcoatInfo(ensureExtensionUsed, coerceNumber, rnMaterial, applyTexture, material);
 


### PR DESCRIPTION
…Gltf2ExporterOps

- Introduced new functions to handle the KHR_materials_iridescence extension, including texture and thickness parameters, enhancing material representation in glTF exports.
- Updated existing functions to register and apply iridescence textures, improving modularity and reusability.
- Ensured proper extension usage tracking for iridescence parameters, contributing to better material management.