### PR TITLE
feat: add KHR_materials_dispersion support in Gltf2Exporter and Gltf2…

### DIFF
--- a/src/foundation/exporter/Gltf2Exporter.ts
+++ b/src/foundation/exporter/Gltf2Exporter.ts
@@ -43,6 +43,7 @@ import {
   __outputBaseMaterialInfo,
   __outputKhrMaterialsAnisotropyInfo,
   __outputKhrMaterialsClearcoatInfo,
+  __outputKhrMaterialsDispersionInfo,
   __outputKhrMaterialsIorInfo,
   __outputKhrMaterialsIridescenceInfo,
   __outputKhrMaterialsSheenInfo,
@@ -883,6 +884,8 @@ export class Gltf2Exporter {
     __outputKhrMaterialsTransmissionInfo(ensureExtensionUsed, coerceNumber, rnMaterial, applyTexture, material);
 
     __outputKhrMaterialsVolumeInfo(ensureExtensionUsed, coerceNumber, coerceVec3, rnMaterial, applyTexture, material);
+
+    __outputKhrMaterialsDispersionInfo(ensureExtensionUsed, coerceNumber, rnMaterial, material);
 
     __outputKhrMaterialsIorInfo(ensureExtensionUsed, coerceNumber, rnMaterial, material);
 

--- a/src/foundation/exporter/Gltf2ExporterOps.ts
+++ b/src/foundation/exporter/Gltf2ExporterOps.ts
@@ -3017,6 +3017,34 @@ export function __outputKhrMaterialsAnisotropyInfo(
   }
 }
 
+export function __outputKhrMaterialsDispersionInfo(
+  ensureExtensionUsed: (extensionName: string) => void,
+  coerceNumber: (value: any) => number | undefined,
+  rnMaterial: Material,
+  material: Gltf2MaterialEx
+) {
+  const rawDispersion = coerceNumber(rnMaterial.getParameter('dispersion'));
+  if (Is.not.exist(rawDispersion)) {
+    return;
+  }
+
+  const dispersion = Math.max(0, rawDispersion);
+  if (!Number.isFinite(dispersion) || dispersion === 0) {
+    return;
+  }
+
+  material.extensions = material.extensions ?? {};
+  material.extensions.KHR_materials_dispersion = {
+    dispersion,
+  };
+  ensureExtensionUsed('KHR_materials_dispersion');
+
+  if (Is.not.exist(material.extensions.KHR_materials_volume)) {
+    material.extensions.KHR_materials_volume = {};
+  }
+  ensureExtensionUsed('KHR_materials_volume');
+}
+
 export function __removeUnusedAccessorsAndBufferViews(json: Gltf2Ex) {
   if (json.accessors.length === 0) {
     __recalculateBufferViewAccumulators(json);


### PR DESCRIPTION
…ExporterOps

- Introduced a new function to handle the KHR_materials_dispersion extension, allowing for the specification of dispersion parameters in glTF exports.
- Updated Gltf2Exporter to utilize the new dispersion function, enhancing material representation capabilities.
- Ensured proper extension usage tracking for dispersion parameters, contributing to improved material management.