### PR TITLE
feat: add support for KHR_lights_punctual in Gltf2Exporter

### DIFF
--- a/src/types/glTF2.ts
+++ b/src/types/glTF2.ts
@@ -344,11 +344,11 @@ export interface Gltf2Accessor {
 export type PointType = 'directional' | 'point' | 'spot';
 
 export type KHR_lights_punctual_Light = {
-  color: Array3<number>;
+  color?: Array3<number>;
   type: PointType;
   name?: string;
   intensity?: number;
-  range: number;
+  range?: number;
   spot?: {
     innerConeAngle?: number;
     outerConeAngle?: number;


### PR DESCRIPTION
- Implemented functionality to export light components in glTF2 format, including point, directional, and spot lights.
- Enhanced the Gltf2Exporter to manage light properties such as color, intensity, and cone angles.
- Ensured proper extension usage tracking for KHR_lights_punctual, contributing to improved scene representation in glTF exports.