### PR TITLE
feat: add KHR_materials_specular support in Gltf2Exporter and Gltf2Ex…

### DIFF
--- a/src/foundation/exporter/Gltf2Exporter.ts
+++ b/src/foundation/exporter/Gltf2Exporter.ts
@@ -51,6 +51,7 @@ import {
   __outputKhrMaterialsIorInfo,
   __outputKhrMaterialsIridescenceInfo,
   __outputKhrMaterialsSheenInfo,
+  __outputKhrMaterialsSpecularInfo,
   __outputKhrMaterialsTransmissionInfo,
   __outputKhrMaterialsVolumeInfo,
   __pruneUnusedVertexAttributes,
@@ -1003,6 +1004,8 @@ export class Gltf2Exporter {
     __outputKhrMaterialsClearcoatInfo(ensureExtensionUsed, coerceNumber, rnMaterial, applyTexture, material);
 
     __outputKhrMaterialsSheenInfo(ensureExtensionUsed, coerceNumber, coerceVec3, rnMaterial, applyTexture, material);
+
+    __outputKhrMaterialsSpecularInfo(ensureExtensionUsed, coerceNumber, coerceVec3, rnMaterial, applyTexture, material);
 
     __outputKhrMaterialsAnisotropyInfo(
       ensureExtensionUsed,


### PR DESCRIPTION
…porterOps

- Introduced functionality to handle the KHR_materials_specular extension, allowing for the specification of specular parameters in glTF exports.
- Updated Gltf2Exporter to utilize the new specular output function, enhancing material representation capabilities.
- Ensured proper extension usage tracking for specular parameters, contributing to improved material management.