### PR TITLE
feat: add KHR_materials_emissive_strength support in Gltf2Exporter

### DIFF
--- a/src/foundation/exporter/Gltf2Exporter.ts
+++ b/src/foundation/exporter/Gltf2Exporter.ts
@@ -48,6 +48,7 @@ import {
   __outputKhrMaterialsClearcoatInfo,
   __outputKhrMaterialsDiffuseTransmissionInfo,
   __outputKhrMaterialsDispersionInfo,
+  __outputKhrMaterialsEmissiveStrengthInfo,
   __outputKhrMaterialsIorInfo,
   __outputKhrMaterialsIridescenceInfo,
   __outputKhrMaterialsSheenInfo,
@@ -981,6 +982,8 @@ export class Gltf2Exporter {
     };
 
     __outputBaseMaterialInfo(rnMaterial, applyTexture, material, json);
+
+    __outputKhrMaterialsEmissiveStrengthInfo(ensureExtensionUsed, coerceNumber, rnMaterial, material);
 
     __outputKhrMaterialsDiffuseTransmissionInfo(
       ensureExtensionUsed,

--- a/src/foundation/exporter/Gltf2ExporterOps.test.ts
+++ b/src/foundation/exporter/Gltf2ExporterOps.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import type { Gltf2MaterialEx } from '../../types/glTF2ForOutput';
+import type { Material } from '../materials/core/Material';
+import { __outputKhrMaterialsEmissiveStrengthInfo } from './Gltf2ExporterOps';
+
+const coerceNumber = (value: unknown) => (typeof value === 'number' ? value : undefined);
+
+const createMaterialStub = (params: Record<string, unknown>, isLighting = true) =>
+  ({
+    isLighting,
+    getParameter: (name: string) => params[name],
+  }) as unknown as Material;
+
+describe('__outputKhrMaterialsEmissiveStrengthInfo', () => {
+  test('writes the extension when emissiveStrength differs from default', () => {
+    const ensureLog: string[] = [];
+    const ensureExtensionUsed = (name: string) => ensureLog.push(name);
+    const rnMaterial = createMaterialStub({ emissiveStrength: 5 }, true);
+    const material: Gltf2MaterialEx = {
+      pbrMetallicRoughness: {},
+    };
+
+    __outputKhrMaterialsEmissiveStrengthInfo(ensureExtensionUsed, coerceNumber, rnMaterial, material);
+
+    expect(material.extensions?.KHR_materials_emissive_strength).toEqual({ emissiveStrength: 5 });
+    expect(ensureLog).toContain('KHR_materials_emissive_strength');
+  });
+
+  test('skips export for unlit materials or default strength', () => {
+    const ensureExtensionUsed = () => {
+      throw new Error('should not be called');
+    };
+    const rnMaterial = createMaterialStub({ emissiveStrength: 2 }, true);
+    const unlitMaterial: Gltf2MaterialEx = {
+      pbrMetallicRoughness: {},
+      extensions: {
+        KHR_materials_unlit: {},
+      },
+    };
+
+    __outputKhrMaterialsEmissiveStrengthInfo(ensureExtensionUsed, coerceNumber, rnMaterial, unlitMaterial);
+    expect(unlitMaterial.extensions?.KHR_materials_emissive_strength).toBeUndefined();
+
+    const rnDefaultMaterial = createMaterialStub({ emissiveStrength: 1 }, true);
+    const defaultMaterial: Gltf2MaterialEx = {
+      pbrMetallicRoughness: {},
+    };
+
+    __outputKhrMaterialsEmissiveStrengthInfo(ensureExtensionUsed, coerceNumber, rnDefaultMaterial, defaultMaterial);
+    expect(defaultMaterial.extensions?.KHR_materials_emissive_strength).toBeUndefined();
+
+    const rnNoLighting = createMaterialStub({ emissiveStrength: 10 }, false);
+    const noLightingMaterial: Gltf2MaterialEx = {
+      pbrMetallicRoughness: {},
+    };
+
+    __outputKhrMaterialsEmissiveStrengthInfo(ensureExtensionUsed, coerceNumber, rnNoLighting, noLightingMaterial);
+    expect(noLightingMaterial.extensions?.KHR_materials_emissive_strength).toBeUndefined();
+  });
+});

--- a/src/foundation/exporter/Gltf2ExporterOps.ts
+++ b/src/foundation/exporter/Gltf2ExporterOps.ts
@@ -2510,6 +2510,37 @@ export function __pruneUnusedVertexAttributes(primitive: Gltf2Primitive, materia
   }
 }
 
+export function __outputKhrMaterialsEmissiveStrengthInfo(
+  ensureExtensionUsed: (extensionName: string) => void,
+  coerceNumber: (value: any) => number | undefined,
+  rnMaterial: Material,
+  material: Gltf2MaterialEx
+) {
+  if (Is.false(rnMaterial.isLighting)) {
+    return;
+  }
+
+  if ((material.extensions as Record<string, unknown> | undefined)?.KHR_materials_unlit) {
+    return;
+  }
+
+  const rawStrength = coerceNumber(rnMaterial.getParameter('emissiveStrength'));
+  if (Is.not.exist(rawStrength)) {
+    return;
+  }
+
+  const emissiveStrength = Math.max(0, rawStrength);
+  if (!Number.isFinite(emissiveStrength) || emissiveStrength === 1) {
+    return;
+  }
+
+  material.extensions = material.extensions ?? {};
+  material.extensions.KHR_materials_emissive_strength = {
+    emissiveStrength,
+  };
+  ensureExtensionUsed('KHR_materials_emissive_strength');
+}
+
 export function __outputKhrMaterialsDiffuseTransmissionInfo(
   ensureExtensionUsed: (extensionName: string) => void,
   coerceNumber: (value: any) => number | undefined,


### PR DESCRIPTION
- Implemented functionality to handle the KHR_materials_emissive_strength extension, allowing for the specification of emissive strength parameters in glTF exports.
- Updated Gltf2Exporter to utilize the new emissive strength output function, enhancing material representation capabilities.
- Added unit tests to ensure correct behavior of the emissive strength output function, including handling of default values and unlit materials.