### PR TITLE
fix: update Gltf2Exporter to handle empty samplers

### DIFF
--- a/src/foundation/exporter/Gltf2ExporterOps.ts
+++ b/src/foundation/exporter/Gltf2ExporterOps.ts
@@ -2282,6 +2282,9 @@ export function __deleteEmptyArrays(json: Gltf2Ex): void {
   if (json.images.length === 0) {
     (json as Gltf2).images = undefined;
   }
+  if (json.samplers.length === 0) {
+    (json as Gltf2).samplers = undefined;
+  }
   if (json.animations.length === 0) {
     (json as Gltf2).animations = undefined;
   }


### PR DESCRIPTION
- Added logic to the __deleteEmptyArrays function to set samplers to undefined when the samplers array is empty, improving the handling of glTF exports.