### PR TITLE
perf: remove material properties from JointGizmo

### DIFF
--- a/src/foundation/gizmos/JointGizmo.ts
+++ b/src/foundation/gizmos/JointGizmo.ts
@@ -150,11 +150,6 @@ export class JointGizmo extends Gizmo {
     primitive.generate({});
     primitive.setWorldPositions(JointGizmo.__origin, JointGizmo.__unitY, 1);
     primitive.setRenderQueue(7);
-    const gizmoMaterial = MaterialHelper.createClassicUberMaterial({ additionalName: 'JointGizmo' });
-    gizmoMaterial.alphaMode = AlphaMode.Blend;
-    gizmoMaterial.zWriteWhenBlend = false;
-    gizmoMaterial.cullFace = false;
-    primitive.material = gizmoMaterial;
     mesh.addPrimitive(primitive);
     meshComponent.setMesh(mesh);
 


### PR DESCRIPTION
- Eliminated the creation and configuration of the gizmo material in JointGizmo, simplifying the rendering process.
- This change aligns with previous updates to material management and enhances performance for blend primitives.