### PR TITLE
perf: simplify SceneGraphComponent and SkeletalComponent logic

### DIFF
--- a/src/foundation/components/SceneGraph/SceneGraphComponent.ts
+++ b/src/foundation/components/SceneGraph/SceneGraphComponent.ts
@@ -68,7 +68,6 @@ export class SceneGraphComponent extends Component {
   private static readonly __originVector3 = Vector3.zero();
   private static returnVector3 = MutableVector3.zero();
   private static __sceneGraphs: WeakRef<SceneGraphComponent>[] = [];
-  private static isJointAABBShouldBeCalculated = false;
   private static invertedMatrix44 = MutableMatrix44.fromCopyArray16ColumnMajor([
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   ]);
@@ -302,7 +301,7 @@ export class SceneGraphComponent extends Component {
    * @param flg - True to show the joint gizmo, false to hide it
    */
   set isJointGizmoVisible(flg: boolean) {
-    if (flg) {
+    if (flg && this.isJoint()) {
       if (Is.not.defined(this.__jointGizmo)) {
         this.__jointGizmo = new JointGizmo(this.entity);
         this.__jointGizmo._setup();

--- a/src/foundation/components/Skeletal/SkeletalComponent.ts
+++ b/src/foundation/components/Skeletal/SkeletalComponent.ts
@@ -298,7 +298,7 @@ export class SkeletalComponent extends Component {
 
     for (let i = 0; i < this.__joints.length; i++) {
       const joint = this.__joints[i];
-      const globalJointTransform = joint.isVisible ? joint.matrixInner : joint.matrixRestInner;
+      const globalJointTransform = joint.matrixInner;
 
       MutableMatrix44.multiplyTypedArrayTo(
         globalJointTransform,


### PR DESCRIPTION
- Removed the static property isJointAABBShouldBeCalculated from SceneGraphComponent to streamline state management.
- Updated the isJointGizmoVisible setter in SceneGraphComponent to check for joint visibility before creating the JointGizmo.
- Simplified globalJointTransform assignment in SkeletalComponent by directly using joint.matrixInner, enhancing clarity and performance.