### PR TITLE
refactor: update Gizmo tagging for specific types

### DIFF
--- a/src/foundation/gizmos/Gizmo.ts
+++ b/src/foundation/gizmos/Gizmo.ts
@@ -113,7 +113,6 @@ export abstract class Gizmo extends RnObject {
   protected setGizmoTag() {
     if (this.__topEntity) {
       this.__topEntity.tryToSetTag({ tag: 'Being', value: 'gizmo' });
-      this.__topEntity.tryToSetTag({ tag: 'Gizmo', value: 'top' });
 
       const sceneGraphs = flattenHierarchy(this.__topEntity.getSceneGraph()!, false);
       for (const sg of sceneGraphs) {

--- a/src/foundation/gizmos/JointGizmo.ts
+++ b/src/foundation/gizmos/JointGizmo.ts
@@ -68,6 +68,7 @@ export class JointGizmo extends Gizmo {
     }
 
     this.setGizmoTag();
+    this.__topEntity.tryToSetTag({ tag: 'Gizmo', value: 'Joint' });
     this._update();
   }
 

--- a/src/foundation/gizmos/LightGizmo.ts
+++ b/src/foundation/gizmos/LightGizmo.ts
@@ -56,6 +56,7 @@ export class LightGizmo extends Gizmo {
     meshComponent.setMesh(LightGizmo.__mesh);
 
     this.setGizmoTag();
+    this.__topEntity.tryToSetTag({ tag: 'Gizmo', value: 'Light' });
   }
 
   /**

--- a/src/foundation/gizmos/LocatorGizmo.ts
+++ b/src/foundation/gizmos/LocatorGizmo.ts
@@ -76,6 +76,7 @@ export class LocatorGizmo extends Gizmo {
     sceneGraphComponent.setMesh(LocatorGizmo.__mesh);
 
     this.setGizmoTag();
+    this.__topEntity.tryToSetTag({ tag: 'Gizmo', value: 'Locator' });
   }
 
   /**

--- a/src/foundation/gizmos/ScaleGizmo.ts
+++ b/src/foundation/gizmos/ScaleGizmo.ts
@@ -289,6 +289,7 @@ export class ScaleGizmo extends Gizmo {
     ScaleGizmo.__latestTargetEntity = this.__target;
 
     this.setGizmoTag();
+    this.__topEntity.tryToSetTag({ tag: 'Gizmo', value: 'Scale' });
   }
 
   /**

--- a/src/foundation/gizmos/TranslationGizmo.ts
+++ b/src/foundation/gizmos/TranslationGizmo.ts
@@ -377,6 +377,7 @@ export class TranslationGizmo extends Gizmo {
     this.__latestTargetEntity = this.__target;
 
     this.setGizmoTag();
+    this.__topEntity.tryToSetTag({ tag: 'Gizmo', value: 'Translation' });
   }
 
   /**


### PR DESCRIPTION
- Removed the generic 'Gizmo' tag from the top entity in the base Gizmo class.
- Added specific 'Gizmo' tags for Joint, Light, Locator, Scale, and Translation gizmos to enhance clarity and categorization in the scene graph.