### PR TITLE
refactor: optimize child iteration in SceneGraphComponent

### DIFF
--- a/src/foundation/components/SceneGraph/SceneGraphComponent.ts
+++ b/src/foundation/components/SceneGraph/SceneGraphComponent.ts
@@ -419,9 +419,9 @@ export class SceneGraphComponent extends Component {
    */
   setWorldMatrixRestDirtyRecursively() {
     this.__isWorldMatrixRestUpToDate = false;
-    this.children.forEach(child => {
+    for (const child of this.children) {
       child.setWorldMatrixRestDirtyRecursively();
-    });
+    }
   }
 
   /**
@@ -441,9 +441,9 @@ export class SceneGraphComponent extends Component {
     this.__isWorldRotationUpToDate = false;
     this.__isWorldAABBDirty = true;
 
-    this.children.forEach(child => {
+    for (const child of this.children) {
       child.setWorldMatrixDirtyRecursively();
-    });
+    }
   }
 
   /**


### PR DESCRIPTION
- Replaced `forEach` with a `for...of` loop in `setWorldMatrixRestDirtyRecursively` and `setWorldMatrixDirtyRecursively` methods for improved performance and readability during recursive updates of child components.