### PR TITLE
refactor: enhance world matrix handling in SceneGraphComponent and VR…

### DIFF
--- a/src/foundation/components/SceneGraph/SceneGraphComponent.ts
+++ b/src/foundation/components/SceneGraph/SceneGraphComponent.ts
@@ -433,9 +433,25 @@ export class SceneGraphComponent extends Component {
   }
 
   /**
+   * Marks the world matrix as dirty without checking if the AABB is dirty.
+   */
+  setWorldMatrixDirtyWithoutAABBDirty() {
+    this.setWorldMatrixDirtyRecursively();
+  }
+
+  /**
    * Recursively marks the world matrix as dirty for this node and all children.
    */
   setWorldMatrixDirtyRecursively() {
+    if (
+      !this.__isWorldMatrixUpToDate &&
+      !this.__isNormalMatrixUpToDate &&
+      !this.__isWorldRotationUpToDate &&
+      this.__isWorldAABBDirty
+    ) {
+      return;
+    }
+
     this.__isWorldMatrixUpToDate = false;
     this.__isNormalMatrixUpToDate = false;
     this.__isWorldRotationUpToDate = false;

--- a/src/foundation/physics/VRMSpring/VRMSpringBonePhysicsStrategy.ts
+++ b/src/foundation/physics/VRMSpring/VRMSpringBonePhysicsStrategy.ts
@@ -191,7 +191,7 @@ export class VRMSpringBonePhysicsStrategy implements PhysicsStrategy {
     const resultRotation = this.applyRotation(nextTail, bone, worldSpacePosition);
 
     bone.node.localRotation = resultRotation;
-    bone.node.getSceneGraph().setWorldMatrixDirty();
+    bone.node.getSceneGraph().setWorldMatrixDirtyWithoutAABBDirty();
   }
 
   /**


### PR DESCRIPTION
…MSpringBonePhysicsStrategy

- Added a new method `setWorldMatrixDirtyWithoutAABBDirty` to SceneGraphComponent for marking the world matrix as dirty without checking AABB status.
- Updated VRMSpringBonePhysicsStrategy to utilize the new method, improving performance by avoiding unnecessary AABB checks during world matrix updates.