### PR TITLE
perf: Update collision handling and bone length calculations

### DIFF
--- a/src/foundation/physics/VRMSpring/SphereCollider.ts
+++ b/src/foundation/physics/VRMSpring/SphereCollider.ts
@@ -54,6 +54,6 @@ export class SphereCollider {
     const radius = this.__radius + boneRadius;
     const distance = length - radius;
 
-    return { distance, direction: distance < 0 ? Vector3.divideTo(delta, length, SphereCollider.__tmp_vec3_2) : delta };
+    return { distance, delta: delta, length };
   }
 }

--- a/src/foundation/physics/VRMSpring/VRMSpringBone.ts
+++ b/src/foundation/physics/VRMSpring/VRMSpringBone.ts
@@ -134,18 +134,15 @@ export class VRMSpringBone extends RnObject {
    * of the bone and its child (or estimated child position).
    */
   _calcWorldSpaceBoneLength(): void {
-    const v3A = this.node.getSceneGraph().matrixInner.getTranslateTo(VRMSpringBone.__tmp_vec3_0);
+    const mat = this.node.getSceneGraph().matrixInner;
+    const v3A = mat.getTranslateTo(VRMSpringBone.__tmp_vec3_0);
     let v3B = VRMSpringBone.__tmp_vec3_2_zero;
     const children = this.node.getSceneGraph().children;
     if (children.length > 0) {
       v3B = children[0].matrixInner.getTranslateTo(VRMSpringBone.__tmp_vec3_1);
     } else {
       // v3B = this.node.getSceneGraph().matrixInner.multiplyVector3(this.initialLocalChildPosition);
-      v3B = Vector3.multiplyMatrix4To(
-        this.initialLocalChildPosition,
-        this.node.getSceneGraph().matrixInner,
-        VRMSpringBone.__tmp_vec3_3
-      );
+      v3B = Vector3.multiplyMatrix4To(this.initialLocalChildPosition, mat, VRMSpringBone.__tmp_vec3_3);
     }
 
     this.boneLength = Vector3.subtractTo(v3A, v3B, VRMSpringBone.__tmp_vec3_4).length();

--- a/src/foundation/physics/VRMSpring/VRMSpringBonePhysicsStrategy.ts
+++ b/src/foundation/physics/VRMSpring/VRMSpringBonePhysicsStrategy.ts
@@ -306,13 +306,13 @@ export class VRMSpringBonePhysicsStrategy implements PhysicsStrategy {
   ) {
     for (const collisionGroup of collisionGroups) {
       for (const collider of collisionGroup.sphereColliders) {
-        const { direction, distance } = collider.collision(nextTail, boneHitRadius);
+        const { delta, distance, length } = collider.collision(nextTail, boneHitRadius);
         if (distance < 0) {
           // Hit
           nextTail = Vector3.addScaledVectorTo(
             nextTail,
-            direction,
-            -distance,
+            delta,
+            (1 / length) * -distance,
             VRMSpringBonePhysicsStrategy.__tmp_collision_vec3_0
           );
 


### PR DESCRIPTION
- Modified the return structure of the SphereCollider's collision method to include delta and length for improved clarity.
- Simplified the bone length calculation in VRMSpringBone by reusing the scene graph matrix, enhancing performance and readability.
- Adjusted the collision handling in VRMSpringBonePhysicsStrategy to utilize the new return values from the collider, improving the logic for handling collisions.