### PR TITLE
fix: Update projection matrix handling in CameraComponent for XR mode

### DIFF
--- a/src/foundation/components/Camera/CameraComponent.ts
+++ b/src/foundation/components/Camera/CameraComponent.ts
@@ -1190,7 +1190,17 @@ export class CameraComponent extends Component {
 
     this.calcViewMatrix();
 
-    if (!this._xrLeft && !this._xrRight) {
+    if (this._xrLeft || this._xrRight) {
+      // In XR mode, get the projection matrix from WebXRSystem
+      const webXRSystem = this.__engine.webXRSystem;
+      if (webXRSystem.isWebXRMode) {
+        if (this._xrLeft) {
+          this._projectionMatrix.copyComponents(webXRSystem.leftProjectionMatrix);
+        } else if (this._xrRight) {
+          this._projectionMatrix.copyComponents(webXRSystem.rightProjectionMatrix);
+        }
+      }
+    } else {
       this.calcProjectionMatrix();
     }
     this.__setValuesToViewPosition();


### PR DESCRIPTION
- Modified the logic to retrieve the projection matrix from WebXRSystem when in XR mode, ensuring correct handling for both left and right eye projections.
- Retained the existing projection matrix calculation for non-XR scenarios to maintain functionality.