### PR TITLE
fix: Enhance entity destruction process

### DIFF
--- a/src/foundation/core/Entity.ts
+++ b/src/foundation/core/Entity.ts
@@ -500,7 +500,8 @@ export class Entity extends RnObject implements IEntity {
    * Destroys this entity and releases all associated resources.
    *
    * @remarks
-   * This method calls the destroy method on all components attached to this entity
+   * This method calls the destroy method on all components attached to this entity,
+   * unregisters the entity from the RnObject tracking system (to clean up unique names),
    * and marks the entity as no longer alive. After calling this method, the entity
    * should not be used.
    */
@@ -508,6 +509,9 @@ export class Entity extends RnObject implements IEntity {
     this.__components.forEach(component => {
       component._destroy();
     });
+    // Unregister from RnObject to clean up unique name registry
+    // This prevents name conflicts when creating new entities with the same name after engine reset
+    this.unregister();
     this._isAlive = false;
   }
 }


### PR DESCRIPTION
- Updated the destroy method in the Entity class to unregister the entity from the RnObject tracking system, preventing name conflicts during engine resets.
- Added comments to clarify the purpose of unregistering and its impact on resource management.