### PR TITLE
feat: Add multi-view support to MToon shaders

### DIFF
--- a/src/webgl/shaderity_shaders/MToon0xSingleShader/MToon0xSingleShader.vert.glsl
+++ b/src/webgl/shaderity_shaders/MToon0xSingleShader/MToon0xSingleShader.vert.glsl
@@ -4,6 +4,10 @@
 
 /* shaderity: @{definitions} */
 
+#ifdef WEBGL2_MULTI_VIEW
+  layout(num_views=2) in;
+#endif
+
 // This shader is based on https://github.com/Santarh/MToon
 
 /* shaderity: @{vertexInOut} */
@@ -92,4 +96,8 @@ void main(){
   v_texcoord_0 = a_texcoord_0;
   v_baryCentricCoord = a_baryCentricCoord.xyz;
   v_instanceInfo = a_instanceInfo.x;
+
+#ifdef WEBGL2_MULTI_VIEW
+  v_displayIdx = float(gl_ViewID_OVR);
+#endif
 }

--- a/src/webgl/shaderity_shaders/MToon1SingleShader/MToon1SingleShader.vert.glsl
+++ b/src/webgl/shaderity_shaders/MToon1SingleShader/MToon1SingleShader.vert.glsl
@@ -4,6 +4,10 @@
 
 /* shaderity: @{definitions} */
 
+#ifdef WEBGL2_MULTI_VIEW
+  layout(num_views=2) in;
+#endif
+
 /* shaderity: @{vertexInOut} */
 out vec3 v_normal_inView;
 
@@ -80,4 +84,8 @@ void main(){
   v_texcoord_2 = a_texcoord_2;
   v_baryCentricCoord = a_baryCentricCoord.xyz;
   v_instanceInfo = a_instanceInfo.x;
+
+#ifdef WEBGL2_MULTI_VIEW
+  v_displayIdx = float(gl_ViewID_OVR);
+#endif
 }


### PR DESCRIPTION
- Implemented layout for multiple views in MToon0xSingleShader and MToon1SingleShader vertex shaders.
- Added handling for view index output in both shaders to support WebGL2 multi-view rendering.