### PR TITLE
feat: Add GreaterOrEqualShaderNode for greater-than-or-equal comparis…

### DIFF
--- a/src/foundation/materials/core/ShaderGraphResolver.ts
+++ b/src/foundation/materials/core/ShaderGraphResolver.ts
@@ -28,6 +28,7 @@ import { ConstantVector3VariableShaderNode } from '../nodes/ConstantVector3Varia
 import { ConstantVector4VariableShaderNode } from '../nodes/ConstantVector4VariableShaderNode';
 import { DiscardShaderNode } from '../nodes/DiscardShaderNode';
 import { DotProductShaderNode } from '../nodes/DotProductShaderNode';
+import { GreaterOrEqualShaderNode } from '../nodes/GreaterOrEqualShaderNode';
 import { GreaterShaderNode } from '../nodes/GreaterShaderNode';
 import { GreaterThanShaderNode } from '../nodes/GreaterThanShaderNode';
 import { LengthShaderNode } from '../nodes/LengthShaderNode';
@@ -1330,6 +1331,23 @@ function constructNodes(json: ShaderNodeJson) {
           nodeInstance = new GreaterThanShaderNode(ComponentType.UnsignedInt);
         } else {
           Logger.default.error(`GreaterThan node: Unknown socket name: ${socketName}`);
+          break;
+        }
+        nodeInstance.setShaderStage(node.controls.shaderStage.value);
+        nodeInstances[node.id] = nodeInstance;
+        break;
+      }
+      case 'GreaterOrEqual': {
+        const socketName = node.inputs.in1.socket.name;
+        let nodeInstance: GreaterOrEqualShaderNode;
+        if (socketName.includes('<float>')) {
+          nodeInstance = new GreaterOrEqualShaderNode(ComponentType.Float);
+        } else if (socketName.includes('<int>')) {
+          nodeInstance = new GreaterOrEqualShaderNode(ComponentType.Int);
+        } else if (socketName.includes('<uint>')) {
+          nodeInstance = new GreaterOrEqualShaderNode(ComponentType.UnsignedInt);
+        } else {
+          Logger.default.error(`GreaterOrEqual node: Unknown socket name: ${socketName}`);
           break;
         }
         nodeInstance.setShaderStage(node.controls.shaderStage.value);

--- a/src/foundation/materials/nodes/GreaterOrEqualShaderNode.ts
+++ b/src/foundation/materials/nodes/GreaterOrEqualShaderNode.ts
@@ -1,0 +1,98 @@
+import GreaterOrEqualShaderityObjectGLSL from '../../../webgl/shaderity_shaders/nodes/GreaterOrEqual.glsl';
+import GreaterOrEqualShaderityObjectWGSL from '../../../webgpu/shaderity_shaders/nodes/GreaterOrEqual.wgsl';
+import { ComponentType, type ComponentTypeEnum } from '../../definitions/ComponentType';
+import { CompositionType } from '../../definitions/CompositionType';
+import { ProcessApproach } from '../../definitions/ProcessApproach';
+import type { Engine } from '../../system/Engine';
+import { AbstractShaderNode } from '../core/AbstractShaderNode';
+import { Socket } from '../core/Socket';
+
+/**
+ * A shader node that performs a greater-than-or-equal comparison operation.
+ *
+ * This node compares two values and outputs a boolean result indicating whether
+ * the left-hand side (lhs) is greater than or equal to the right-hand side (rhs).
+ * Both operands must be of the same component type (float, int, or uint).
+ *
+ * @example
+ * ```typescript
+ * // Create a greater-than-or-equal comparison node for float values
+ * const greaterOrEqualNode = new GreaterOrEqualShaderNode(ComponentType.Float);
+ * ```
+ */
+export class GreaterOrEqualShaderNode extends AbstractShaderNode {
+  /**
+   * Creates a new GreaterOrEqualShaderNode instance.
+   *
+   * @param componentType - The component type of the inputs (Float, Int, or UnsignedInt)
+   *
+   * @remarks
+   * The node will have two inputs:
+   * - `lhs`: Left-hand side operand with Scalar composition and the specified component type
+   * - `rhs`: Right-hand side operand with Scalar composition and the specified component type
+   *
+   * The output is always a boolean scalar indicating the comparison result.
+   */
+  constructor(componentType: ComponentTypeEnum) {
+    super('_greaterOrEqual', {
+      codeGLSL: GreaterOrEqualShaderityObjectGLSL.code,
+      codeWGSL: GreaterOrEqualShaderityObjectWGSL.code,
+    });
+
+    this.__inputs.push(new Socket('lhs', CompositionType.Scalar, componentType));
+    this.__inputs.push(new Socket('rhs', CompositionType.Scalar, componentType));
+    this.__outputs.push(new Socket('outValue', CompositionType.Scalar, ComponentType.Bool));
+  }
+
+  /**
+   * Gets the input socket for the left-hand side value.
+   *
+   * @returns The input socket for the left operand
+   */
+  getSocketInputLhs() {
+    return this.__inputs[0];
+  }
+
+  /**
+   * Gets the input socket for the right-hand side value.
+   *
+   * @returns The input socket for the right operand
+   */
+  getSocketInputRhs() {
+    return this.__inputs[1];
+  }
+
+  /**
+   * Gets the output socket that provides the comparison result.
+   *
+   * @returns The output socket containing the boolean comparison result
+   */
+  getSocketOutput() {
+    return this.__outputs[0];
+  }
+
+  /**
+   * Gets the appropriate shader function name based on the current rendering approach and input type.
+   * For WebGPU, returns a type-specific function name (e.g., '_greaterOrEqualF32', '_greaterOrEqualI32').
+   * For WebGL, returns the base function name '_greaterOrEqual'.
+   *
+   * @param engine - The engine instance
+   * @returns The shader function name to use in the generated shader code
+   * @throws {Error} Throws an error if the component type is not supported for WebGPU
+   */
+  getShaderFunctionNameDerivative(engine: Engine): string {
+    if (engine.engineState.currentProcessApproach === ProcessApproach.WebGPU) {
+      if (this.__inputs[0].componentType === ComponentType.Float) {
+        return '_greaterOrEqualF32';
+      }
+      if (this.__inputs[0].componentType === ComponentType.Int) {
+        return '_greaterOrEqualI32';
+      }
+      if (this.__inputs[0].componentType === ComponentType.UnsignedInt) {
+        return '_greaterOrEqualU32';
+      }
+      throw new Error('Not supported component type.');
+    }
+    return this.__shaderFunctionName;
+  }
+}

--- a/src/foundation/materials/nodes/index.ts
+++ b/src/foundation/materials/nodes/index.ts
@@ -14,6 +14,7 @@ export * from './ConstantVector3VariableShaderNode';
 export * from './ConstantVector4VariableShaderNode';
 export * from './DiscardShaderNode';
 export * from './DotProductShaderNode';
+export * from './GreaterOrEqualShaderNode';
 export * from './GreaterShaderNode';
 export * from './GreaterThanShaderNode';
 export * from './IfStatementShaderNode';

--- a/src/webgl/shaderity_shaders/nodes/GreaterOrEqual.glsl
+++ b/src/webgl/shaderity_shaders/nodes/GreaterOrEqual.glsl
@@ -1,0 +1,13 @@
+
+void _greaterOrEqual(in float lhs, in float rhs, out bool outValue) {
+  outValue = lhs >= rhs;
+}
+
+void _greaterOrEqual(in int lhs, in int rhs, out bool outValue) {
+  outValue = lhs >= rhs;
+}
+
+void _greaterOrEqual(in uint lhs, in uint rhs, out bool outValue) {
+  outValue = lhs >= rhs;
+}
+

--- a/src/webgpu/shaderity_shaders/nodes/GreaterOrEqual.wgsl
+++ b/src/webgpu/shaderity_shaders/nodes/GreaterOrEqual.wgsl
@@ -1,0 +1,10 @@
+fn _greaterOrEqualF32(lhs: f32, rhs: f32, outValue: ptr<function, bool>) {
+  *outValue = lhs >= rhs;
+}
+fn _greaterOrEqualI32(lhs: i32, rhs: i32, outValue: ptr<function, bool>) {
+  *outValue = lhs >= rhs;
+}
+fn _greaterOrEqualU32(lhs: u32, rhs: u32, outValue: ptr<function, bool>) {
+  *outValue = lhs >= rhs;
+}
+


### PR DESCRIPTION
…on in shaders

- Introduced GreaterOrEqualShaderNode to perform greater-than-or-equal operations on float, int, and uint types.
- Implemented instantiation logic in ShaderGraphResolver to handle input socket types and added error logging for unknown socket names.
- Added GLSL and WGSL shader implementations for the greater-than-or-equal functionality.
- Updated index.ts to export the new GreaterOrEqualShaderNode.