### PR TITLE
feat: Add OrShaderNode for logical OR operation in shaders

### DIFF
--- a/src/foundation/materials/core/ShaderGraphResolver.ts
+++ b/src/foundation/materials/core/ShaderGraphResolver.ts
@@ -40,6 +40,7 @@ import { MultiplyShaderNode } from '../nodes/MultiplyShaderNode';
 import { NormalMatrixShaderNode } from '../nodes/NormalMatrixShaderNode';
 import { NormalizeShaderNode } from '../nodes/NormalizeShaderNode';
 import { NotEqualShaderNode } from '../nodes/NotEqualShaderNode';
+import { OrShaderNode } from '../nodes/OrShaderNode';
 import { OutColorShaderNode } from '../nodes/OutColorShaderNode';
 import { OutPositionShaderNode } from '../nodes/OutPositionShaderNode';
 import { ProcessGeometryShaderNode } from '../nodes/ProcessGeometryShaderNode';
@@ -1392,6 +1393,12 @@ function constructNodes(json: ShaderNodeJson) {
       }
       case 'And': {
         const nodeInstance = new AndShaderNode();
+        nodeInstance.setShaderStage(node.controls.shaderStage.value);
+        nodeInstances[node.id] = nodeInstance;
+        break;
+      }
+      case 'Or': {
+        const nodeInstance = new OrShaderNode();
         nodeInstance.setShaderStage(node.controls.shaderStage.value);
         nodeInstances[node.id] = nodeInstance;
         break;

--- a/src/foundation/materials/nodes/OrShaderNode.ts
+++ b/src/foundation/materials/nodes/OrShaderNode.ts
@@ -1,0 +1,68 @@
+import OrShaderityObjectGLSL from '../../../webgl/shaderity_shaders/nodes/Or.glsl';
+import OrShaderityObjectWGSL from '../../../webgpu/shaderity_shaders/nodes/Or.wgsl';
+import { ComponentType } from '../../definitions/ComponentType';
+import { CompositionType } from '../../definitions/CompositionType';
+import { AbstractShaderNode } from '../core/AbstractShaderNode';
+import { Socket } from '../core/Socket';
+
+/**
+ * A shader node that performs a logical OR operation on two boolean values.
+ *
+ * This node takes two boolean inputs and outputs the result of the logical OR operation.
+ * The output is true when at least one of the inputs is true.
+ *
+ * @example
+ * ```typescript
+ * // Create an OR node
+ * const orNode = new OrShaderNode();
+ * ```
+ */
+export class OrShaderNode extends AbstractShaderNode {
+  /**
+   * Creates a new OrShaderNode instance.
+   *
+   * @remarks
+   * The node will have two boolean inputs:
+   * - `lhs`: Left-hand side operand (boolean)
+   * - `rhs`: Right-hand side operand (boolean)
+   *
+   * The output is a boolean scalar indicating the OR result.
+   */
+  constructor() {
+    super('_or', {
+      codeGLSL: OrShaderityObjectGLSL.code,
+      codeWGSL: OrShaderityObjectWGSL.code,
+    });
+
+    this.__inputs.push(new Socket('lhs', CompositionType.Scalar, ComponentType.Bool));
+    this.__inputs.push(new Socket('rhs', CompositionType.Scalar, ComponentType.Bool));
+    this.__outputs.push(new Socket('outValue', CompositionType.Scalar, ComponentType.Bool));
+  }
+
+  /**
+   * Gets the input socket for the left-hand side boolean value.
+   *
+   * @returns The input socket for the left operand
+   */
+  getSocketInputLhs() {
+    return this.__inputs[0];
+  }
+
+  /**
+   * Gets the input socket for the right-hand side boolean value.
+   *
+   * @returns The input socket for the right operand
+   */
+  getSocketInputRhs() {
+    return this.__inputs[1];
+  }
+
+  /**
+   * Gets the output socket that provides the OR result.
+   *
+   * @returns The output socket containing the boolean OR result
+   */
+  getSocketOutput() {
+    return this.__outputs[0];
+  }
+}

--- a/src/foundation/materials/nodes/index.ts
+++ b/src/foundation/materials/nodes/index.ts
@@ -27,6 +27,7 @@ export * from './MultiplyShaderNode';
 export * from './NormalizeShaderNode';
 export * from './NormalMatrixShaderNode';
 export * from './NotEqualShaderNode';
+export * from './OrShaderNode';
 export * from './OutColorShaderNode';
 export * from './OutPositionShaderNode';
 export * from './ProjectionMatrixShaderNode';

--- a/src/webgl/shaderity_shaders/nodes/Or.glsl
+++ b/src/webgl/shaderity_shaders/nodes/Or.glsl
@@ -1,0 +1,5 @@
+
+void _or(in bool lhs, in bool rhs, out bool outValue) {
+  outValue = lhs || rhs;
+}
+

--- a/src/webgpu/shaderity_shaders/nodes/Or.wgsl
+++ b/src/webgpu/shaderity_shaders/nodes/Or.wgsl
@@ -1,0 +1,4 @@
+fn _or(lhs: bool, rhs: bool, outValue: ptr<function, bool>) {
+  *outValue = lhs || rhs;
+}
+


### PR DESCRIPTION
- Introduced OrShaderNode to perform logical OR operations on two boolean inputs.
- Implemented instantiation logic in ShaderGraphResolver to handle the new node type.
- Added GLSL and WGSL shader implementations for the OR functionality.
- Updated index.ts to export the new OrShaderNode.