### PR TITLE
fix: Rename UniformVector4 case to UniformVector4Float in ShaderGraph…

### DIFF
--- a/src/foundation/materials/core/ShaderGraphResolver.ts
+++ b/src/foundation/materials/core/ShaderGraphResolver.ts
@@ -934,7 +934,7 @@ function constructNodes(json: ShaderNodeJson) {
         nodeInstances[node.id] = nodeInstance;
         break;
       }
-      case 'UniformVector4': {
+      case 'UniformVector4Float': {
         const nodeInstance = new UniformDataShaderNode(CompositionType.Vec4, ComponentType.Float);
         nodeInstance.setDefaultInputValue(
           'value',


### PR DESCRIPTION
…Resolver

- Updated the case name in the constructNodes function to accurately reflect the data type being handled for uniform vector inputs.