### PR TITLE
feat: Add support for UniformScalarFloat in ShaderGraphResolver

### DIFF
--- a/src/foundation/materials/core/ShaderGraphResolver.ts
+++ b/src/foundation/materials/core/ShaderGraphResolver.ts
@@ -934,6 +934,13 @@ function constructNodes(json: ShaderNodeJson) {
         nodeInstances[node.id] = nodeInstance;
         break;
       }
+      case 'UniformScalarFloat': {
+        const nodeInstance = new UniformDataShaderNode(CompositionType.Scalar, ComponentType.Float);
+        nodeInstance.setDefaultInputValue('value', Scalar.fromCopyNumber(node.controls.initialValue.value));
+        nodeInstance.setUniformDataName(node.controls.name.value);
+        nodeInstances[node.id] = nodeInstance;
+        break;
+      }
       case 'UniformVector4Float': {
         const nodeInstance = new UniformDataShaderNode(CompositionType.Vec4, ComponentType.Float);
         nodeInstance.setDefaultInputValue(


### PR DESCRIPTION
- Introduced a new case for UniformScalarFloat in the constructNodes function to handle scalar float uniform inputs.
- Set default input value and uniform data name for the new node type.