### PR TITLE
feat: Add support for UniformVector2Float in ShaderGraphResolver

### DIFF
--- a/src/foundation/materials/core/ShaderGraphResolver.ts
+++ b/src/foundation/materials/core/ShaderGraphResolver.ts
@@ -941,6 +941,16 @@ function constructNodes(json: ShaderNodeJson) {
         nodeInstances[node.id] = nodeInstance;
         break;
       }
+      case 'UniformVector2Float': {
+        const nodeInstance = new UniformDataShaderNode(CompositionType.Vec2, ComponentType.Float);
+        nodeInstance.setDefaultInputValue(
+          'value',
+          Vector2.fromCopy2(node.controls.initialX.value, node.controls.initialY.value)
+        );
+        nodeInstance.setUniformDataName(node.controls.name.value);
+        nodeInstances[node.id] = nodeInstance;
+        break;
+      }
       case 'UniformVector4Float': {
         const nodeInstance = new UniformDataShaderNode(CompositionType.Vec4, ComponentType.Float);
         nodeInstance.setDefaultInputValue(


### PR DESCRIPTION
- Introduced a new case for UniformVector2Float in the constructNodes function to handle vector2 float uniform inputs.
- Set default input value and uniform data name for the new node type.