### PR TITLE
feat: Introduce RemapShaderNode for value remapping in shaders

### DIFF
--- a/src/foundation/materials/core/ShaderGraphResolver.ts
+++ b/src/foundation/materials/core/ShaderGraphResolver.ts
@@ -46,6 +46,7 @@ import { OutColorShaderNode } from '../nodes/OutColorShaderNode';
 import { OutPositionShaderNode } from '../nodes/OutPositionShaderNode';
 import { ProcessGeometryShaderNode } from '../nodes/ProcessGeometryShaderNode';
 import { ProjectionMatrixShaderNode } from '../nodes/ProjectionMatrixShaderNode';
+import { RemapShaderNode } from '../nodes/RemapShaderNode';
 import { SinShaderNode } from '../nodes/SinShaderNode';
 import { SmoothStepShaderNode } from '../nodes/SmoothStepShaderNode';
 import { SplitVectorShaderNode } from '../nodes/SplitVectorShaderNode';
@@ -1098,6 +1099,25 @@ function constructNodes(json: ShaderNodeJson): {
           nodeInstance = new ClampShaderNode(CompositionType.Vec4, ComponentType.Float);
         } else {
           Logger.default.error(`Clamp node: Unknown socket name: ${socketName}`);
+          break;
+        }
+        nodeInstance.setShaderStage(node.controls.shaderStage.value);
+        nodeInstances[node.id] = nodeInstance;
+        break;
+      }
+      case 'Remap': {
+        const socketName = node.outputs.out1.socket.name;
+        let nodeInstance: RemapShaderNode;
+        if (socketName.startsWith('Scalar')) {
+          nodeInstance = new RemapShaderNode(CompositionType.Scalar, ComponentType.Float);
+        } else if (socketName.startsWith('Vector2')) {
+          nodeInstance = new RemapShaderNode(CompositionType.Vec2, ComponentType.Float);
+        } else if (socketName.startsWith('Vector3')) {
+          nodeInstance = new RemapShaderNode(CompositionType.Vec3, ComponentType.Float);
+        } else if (socketName.startsWith('Vector4')) {
+          nodeInstance = new RemapShaderNode(CompositionType.Vec4, ComponentType.Float);
+        } else {
+          Logger.default.error(`Remap node: Unknown socket name: ${socketName}`);
           break;
         }
         nodeInstance.setShaderStage(node.controls.shaderStage.value);

--- a/src/foundation/materials/nodes/RemapShaderNode.ts
+++ b/src/foundation/materials/nodes/RemapShaderNode.ts
@@ -1,0 +1,96 @@
+import RemapShaderityObjectGLSL from '../../../webgl/shaderity_shaders/nodes/Remap.glsl';
+import RemapShaderityObjectWGSL from '../../../webgpu/shaderity_shaders/nodes/Remap.wgsl';
+import type { ComponentTypeEnum } from '../../definitions/ComponentType';
+import { CompositionType, type CompositionTypeEnum } from '../../definitions/CompositionType';
+import { ProcessApproach } from '../../definitions/ProcessApproach';
+import type { Engine } from '../../system/Engine';
+import { AbstractShaderNode } from '../core/AbstractShaderNode';
+import { Socket } from '../core/Socket';
+
+/**
+ * A shader node that remaps a value from one range to another.
+ *
+ * The remap function takes a value from the source range [sourceMin, sourceMax]
+ * and maps it to the target range [targetMin, targetMax].
+ * Formula: outValue = targetMin + ((value - sourceMin) / (sourceMax - sourceMin)) * (targetMax - targetMin)
+ *
+ * @example
+ * ```typescript
+ * const remapNode = new RemapShaderNode(
+ *   CompositionType.Vec3,
+ *   ComponentType.Float
+ * );
+ * ```
+ */
+export class RemapShaderNode extends AbstractShaderNode {
+  /**
+   * Creates a new RemapShaderNode instance.
+   *
+   * @param compositionType - The composition type (Scalar, Vec2, Vec3, Vec4) for the shader node
+   * @param componentType - The component type (Float, Int, etc.) for the shader node
+   */
+  constructor(compositionType: CompositionTypeEnum, componentType: ComponentTypeEnum) {
+    super('_remap', {
+      codeGLSL: RemapShaderityObjectGLSL.code,
+      codeWGSL: RemapShaderityObjectWGSL.code,
+    });
+
+    this.__inputs.push(new Socket('value', compositionType, componentType));
+    this.__inputs.push(new Socket('sourceMin', compositionType, componentType));
+    this.__inputs.push(new Socket('sourceMax', compositionType, componentType));
+    this.__inputs.push(new Socket('targetMin', compositionType, componentType));
+    this.__inputs.push(new Socket('targetMax', compositionType, componentType));
+    this.__outputs.push(new Socket('outValue', compositionType, componentType));
+  }
+
+  /**
+   * Gets the input socket for the value parameter of the remap function.
+   *
+   * This is the value to be remapped from source range to target range.
+   *
+   * @returns The input socket for the value parameter
+   */
+  getSocketInputValue() {
+    return this.__inputs[0];
+  }
+
+  /**
+   * Gets the output socket that contains the result of the remap operation.
+   *
+   * The output will be the input value remapped from [sourceMin, sourceMax] to [targetMin, targetMax].
+   *
+   * @returns The output socket containing the remap result
+   */
+  getSocketOutput() {
+    return this.__outputs[0];
+  }
+
+  /**
+   * Gets the appropriate shader function name based on the current process approach and composition type.
+   *
+   * For WebGPU, the function name includes a type suffix (F32, Vec2f, Vec3f, Vec4f) to match
+   * WGSL naming conventions. For other approaches (WebGL), the base function name is used.
+   *
+   * @param engine - The engine instance
+   * @returns The shader function name with appropriate type suffix for the current context
+   * @throws {Error} If the composition type is not supported
+   */
+  getShaderFunctionNameDerivative(engine: Engine) {
+    if (engine.engineState.currentProcessApproach === ProcessApproach.WebGPU) {
+      if (this.__inputs[0].compositionType === CompositionType.Scalar) {
+        return `${this.__shaderFunctionName}F32`;
+      }
+      if (this.__inputs[0].compositionType === CompositionType.Vec2) {
+        return `${this.__shaderFunctionName}Vec2f`;
+      }
+      if (this.__inputs[0].compositionType === CompositionType.Vec3) {
+        return `${this.__shaderFunctionName}Vec3f`;
+      }
+      if (this.__inputs[0].compositionType === CompositionType.Vec4) {
+        return `${this.__shaderFunctionName}Vec4f`;
+      }
+      throw new Error('Not implemented');
+    }
+    return this.__shaderFunctionName;
+  }
+}

--- a/src/foundation/materials/nodes/index.ts
+++ b/src/foundation/materials/nodes/index.ts
@@ -32,6 +32,7 @@ export * from './OrShaderNode';
 export * from './OutColorShaderNode';
 export * from './OutPositionShaderNode';
 export * from './ProjectionMatrixShaderNode';
+export * from './RemapShaderNode';
 export * from './SplitVectorShaderNode';
 export * from './TextureShaderNode';
 export * from './UniformDataShaderNode';

--- a/src/webgl/shaderity_shaders/nodes/Remap.glsl
+++ b/src/webgl/shaderity_shaders/nodes/Remap.glsl
@@ -1,0 +1,16 @@
+void _remap(in float value, in float sourceMin, in float sourceMax, in float targetMin, in float targetMax, out float outValue) {
+  float t = (value - sourceMin) / (sourceMax - sourceMin);
+  outValue = targetMin + t * (targetMax - targetMin);
+}
+void _remap(in vec2 value, in vec2 sourceMin, in vec2 sourceMax, in vec2 targetMin, in vec2 targetMax, out vec2 outValue) {
+  vec2 t = (value - sourceMin) / (sourceMax - sourceMin);
+  outValue = targetMin + t * (targetMax - targetMin);
+}
+void _remap(in vec3 value, in vec3 sourceMin, in vec3 sourceMax, in vec3 targetMin, in vec3 targetMax, out vec3 outValue) {
+  vec3 t = (value - sourceMin) / (sourceMax - sourceMin);
+  outValue = targetMin + t * (targetMax - targetMin);
+}
+void _remap(in vec4 value, in vec4 sourceMin, in vec4 sourceMax, in vec4 targetMin, in vec4 targetMax, out vec4 outValue) {
+  vec4 t = (value - sourceMin) / (sourceMax - sourceMin);
+  outValue = targetMin + t * (targetMax - targetMin);
+}

--- a/src/webgpu/shaderity_shaders/nodes/Remap.wgsl
+++ b/src/webgpu/shaderity_shaders/nodes/Remap.wgsl
@@ -1,0 +1,16 @@
+fn _remapF32(value: f32, sourceMin: f32, sourceMax: f32, targetMin: f32, targetMax: f32, outValue: ptr<function, f32>) {
+  let t = (value - sourceMin) / (sourceMax - sourceMin);
+  *outValue = targetMin + t * (targetMax - targetMin);
+}
+fn _remapVec2f(value: vec2<f32>, sourceMin: vec2<f32>, sourceMax: vec2<f32>, targetMin: vec2<f32>, targetMax: vec2<f32>, outValue: ptr<function, vec2<f32>>) {
+  let t = (value - sourceMin) / (sourceMax - sourceMin);
+  *outValue = targetMin + t * (targetMax - targetMin);
+}
+fn _remapVec3f(value: vec3<f32>, sourceMin: vec3<f32>, sourceMax: vec3<f32>, targetMin: vec3<f32>, targetMax: vec3<f32>, outValue: ptr<function, vec3<f32>>) {
+  let t = (value - sourceMin) / (sourceMax - sourceMin);
+  *outValue = targetMin + t * (targetMax - targetMin);
+}
+fn _remapVec4f(value: vec4<f32>, sourceMin: vec4<f32>, sourceMax: vec4<f32>, targetMin: vec4<f32>, targetMax: vec4<f32>, outValue: ptr<function, vec4<f32>>) {
+  let t = (value - sourceMin) / (sourceMax - sourceMin);
+  *outValue = targetMin + t * (targetMax - targetMin);
+}


### PR DESCRIPTION
- Added RemapShaderNode to facilitate remapping values from one range to another in shader graphs.
- Implemented GLSL and WGSL shader functions for the remap operation.
- Updated ShaderGraphResolver to handle RemapShaderNode based on socket types (Scalar, Vector2, Vector3, Vector4).
- Included error logging for unknown socket names to enhance debugging capabilities.
- Exported RemapShaderNode in the index file for accessibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `RemapShaderNode` (scalar/vec2/vec3/vec4) with GLSL/WGSL implementations and integrates it into `ShaderGraphResolver`, plus exports.
> 
> - **Shader Nodes**:
>   - Add `RemapShaderNode` handling remap of values across ranges for `Scalar`, `Vec2`, `Vec3`, `Vec4`.
>   - Implements WebGL (`webgl/shaderity_shaders/nodes/Remap.glsl`) and WebGPU (`webgpu/shaderity_shaders/nodes/Remap.wgsl`) functions with type-specific variants.
> - **Resolver Integration**:
>   - Update `ShaderGraphResolver` to construct `Remap` nodes based on socket type and set shader stage; logs on unknown sockets.
> - **Exports**:
>   - Export `RemapShaderNode` in `nodes/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a1af977881346d16108babdc4e06947db7edd17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->