### PR TITLE
fix: Update event handling in gizmos to prevent default behavior…

### DIFF
--- a/src/foundation/gizmos/RotationGizmo.ts
+++ b/src/foundation/gizmos/RotationGizmo.ts
@@ -25,7 +25,7 @@ import { Vector4 } from '../math/Vector4';
 import { Is } from '../misc/Is';
 import { assertExist } from '../misc/MiscUtil';
 import type { Engine } from '../system/Engine';
-import { INPUT_HANDLING_STATE_GIZMO_ROTATION, InputManager, getEvent } from '../system/InputManager';
+import { getEvent, INPUT_HANDLING_STATE_GIZMO_ROTATION, InputManager } from '../system/InputManager';
 import { Gizmo } from './Gizmo';
 
 declare let window: any;
@@ -349,7 +349,6 @@ export class RotationGizmo extends Gizmo {
   }
 
   private __onPointerDown(evt: PointerEvent) {
-    evt.preventDefault();
     this.__isPointerDown = true;
     this.__activePointerElement = undefined;
     this.__pointerPrev.setComponents(0, 0);
@@ -378,6 +377,9 @@ export class RotationGizmo extends Gizmo {
       return;
     }
 
+    // Only prevent default after confirming an axis was picked
+    // This allows camera controller to handle events when gizmo is not being used
+    evt.preventDefault();
     this.__disableCameraController();
     this.__targetRotationBackup = Quaternion.fromCopyQuaternion(this.__target.getTransform().localRotation);
     this.__deltaQuaternion = Quaternion.fromCopyQuaternion(this.__targetRotationBackup);

--- a/src/foundation/gizmos/ScaleGizmo.ts
+++ b/src/foundation/gizmos/ScaleGizmo.ts
@@ -24,7 +24,7 @@ import { Is } from '../misc/Is';
 import { Logger } from '../misc/Logger';
 import { assertExist } from '../misc/MiscUtil';
 import type { Engine } from '../system/Engine';
-import { INPUT_HANDLING_STATE_GIZMO_SCALE, InputManager, getEvent } from '../system/InputManager';
+import { getEvent, INPUT_HANDLING_STATE_GIZMO_SCALE, InputManager } from '../system/InputManager';
 import { Gizmo } from './Gizmo';
 
 declare let window: any;
@@ -568,7 +568,6 @@ export class ScaleGizmo extends Gizmo {
    * @private
    */
   private __onPointerDown(evt: PointerEvent) {
-    evt.preventDefault();
     this.__isPointerDown = true;
     ScaleGizmo.__activeAxis = 'none';
     ScaleGizmo.__originalX = evt.clientX;
@@ -623,6 +622,9 @@ export class ScaleGizmo extends Gizmo {
       return;
     }
 
+    // Only prevent default after confirming an axis was picked
+    // This allows camera controller to handle events when gizmo is not being used
+    evt.preventDefault();
     this.__disableCameraController();
 
     if (ScaleGizmo.__latestTargetEntity === this.__target) {

--- a/src/foundation/gizmos/TranslationGizmo.ts
+++ b/src/foundation/gizmos/TranslationGizmo.ts
@@ -28,7 +28,7 @@ import { Is } from '../misc/Is';
 import { Logger } from '../misc/Logger';
 import { assertExist } from '../misc/MiscUtil';
 import type { Engine } from '../system/Engine';
-import { INPUT_HANDLING_STATE_GIZMO_TRANSLATION, InputManager, getEvent } from '../system/InputManager';
+import { getEvent, INPUT_HANDLING_STATE_GIZMO_TRANSLATION, InputManager } from '../system/InputManager';
 import { Gizmo } from './Gizmo';
 
 declare let window: any;
@@ -563,7 +563,6 @@ export class TranslationGizmo extends Gizmo {
    * @param evt - The pointer event containing click information
    */
   private __onPointerDown(evt: PointerEvent) {
-    evt.preventDefault();
     this.__isPointerDown = true;
     TranslationGizmo.__activeAxis = 'none';
     TranslationGizmo.__originalX = evt.clientX;
@@ -622,6 +621,9 @@ export class TranslationGizmo extends Gizmo {
       return;
     }
 
+    // Only prevent default after confirming an axis was picked
+    // This allows camera controller to handle events when gizmo is not being used
+    evt.preventDefault();
     this.__disableCameraController();
 
     if (this.__latestTargetEntity === this.__target) {


### PR DESCRIPTION
… conditionally

- Rearranged import statements for consistency across RotationGizmo, ScaleGizmo, and TranslationGizmo.
- Modified pointer event handling to only prevent default behavior after confirming an axis is picked, allowing camera controls to function when the gizmo is not in use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make Rotation/Scale/Translation gizmos call preventDefault on pointer down only after an axis is picked, allowing camera controls when not interacting with a gizmo.
> 
> - **Gizmos**:
>   - **Pointer handling**: `preventDefault()` moved to occur only after an axis is selected in `__onPointerDown` for `RotationGizmo`, `ScaleGizmo`, and `TranslationGizmo`, ensuring camera controls remain active when no gizmo axis is picked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a5248973a2c05d65cba0dc22534441b179485bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->