### PR TITLE
fix: Add shadow handling based on ClassicShader node presence

### DIFF
--- a/src/foundation/importer/RhodoniteImportExtension.ts
+++ b/src/foundation/importer/RhodoniteImportExtension.ts
@@ -118,6 +118,12 @@ export class RhodoniteImportExtension {
     // Build texture semantic info from the texture infos extracted during shader generation
     const additionalShaderSemanticInfo = this.__buildTextureSemanticInfo(engine, shaderCode.textureInfos);
 
+    // Check if ClassicShader node is present in the shader node graph
+    const hasClassicShaderNode =
+      ((extension.shaderNodeJson as any)?.nodes?.some(
+        (node: { name: string }) => node.name === 'ClassicShader'
+      ) as boolean) ?? false;
+
     // Create custom material using MaterialHelper
     const newMaterial = MaterialHelper.reuseOrRecreateCustomMaterial(
       engine,
@@ -129,6 +135,7 @@ export class RhodoniteImportExtension {
         isSkinning: true,
         isLighting: true,
         isMorphing: true,
+        isShadow: hasClassicShaderNode,
         additionalShaderSemanticInfo,
       }
     );


### PR DESCRIPTION
- Implemented a check for the presence of the ClassicShader node in the shader node graph.
- Updated material creation to include shadow handling based on the existence of the ClassicShader node, enhancing rendering capabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects `ClassicShader` in shader graph and sets `isShadow` on custom material during node-based material creation.
> 
> - **Importer — `createNodeBasedMaterial`**:
>   - Detect presence of `ClassicShader` node in `extension.shaderNodeJson`.
>   - Pass `isShadow` to `MaterialHelper.reuseOrRecreateCustomMaterial` based on detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0f52d92c1d8c4d32a98e65cc4a3f7e414bf89a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->