### PR TITLE
fix: Pnpm lefthook configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,8 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.28.0"
+  "packageManager": "pnpm@10.28.0",
+  "pnpm": {
+    "onlyBuiltDependencies": ["lefthook"]
+  }
 }


### PR DESCRIPTION
Add pnpm configuration for `lefthook` to ensure git hooks are installed.

pnpm v10 blocks dependency lifecycle scripts by default for security. Without adding `lefthook` to `pnpm.onlyBuiltDependencies`, its `postinstall` script, which installs git hooks, would not execute, silently preventing pre-commit and pre-push checks from running.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configures pnpm to build `lefthook` so its `postinstall` can install git hooks.
> 
> - Adds `pnpm.onlyBuiltDependencies: ["lefthook"]` in `package.json` (pnpm v10 blocks lifecycle scripts by default)
> - Keeps existing `packageManager` unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daf7a0f53d1d266c5bf74717f812301a0e43fa6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->