### PR TITLE
fix: Lefthook pre-commit glob

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,7 +5,7 @@ pre-commit:
   parallel: true
   commands:
     biome-check:
-      glob: "*.{js,ts,jsx,tsx,json}"
+      glob: "**/*.{js,ts,jsx,tsx,json}"
       run: ./node_modules/.bin/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
 
 pre-push:


### PR DESCRIPTION
Update `lefthook.yml` glob pattern to recursively match files in subdirectories.

The previous glob pattern `*.{js,ts,jsx,tsx,json}` only matched files at the root level, causing the pre-commit hook to skip all source files located in subdirectories like `src/` and `samples/`.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands Biome checks to all staged files in nested directories.
> 
> - Updates `lefthook.yml` pre-commit `glob` from `*.{js,ts,jsx,tsx,json}` to `**/*.{js,ts,jsx,tsx,json}` so checks run on files in subdirectories
> - Pre-push command remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 969c4009a3276143e069658966407d9d431bca34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->